### PR TITLE
[김정훈] fe-newsstand 3주차

### DIFF
--- a/css/list.css
+++ b/css/list.css
@@ -54,10 +54,18 @@
   height: 260px;
 }
 
+.list-content .list-news .main-news .img-container {
+  height: 200px;
+}
+
+.list-content .list-news .main-news .img-container img {
+  transition: 0.5s;
+}
+
 .list-content .list-news .main-title {
   width: 320px;
   height: 44px;
-  margin-top: 10px;
+  margin-top: 15px;
   color: #14212b;
   font-weight: 500;
   font-size: 16px;
@@ -76,7 +84,12 @@
   flex-wrap: wrap;
   align-content: space-between;
 }
-
+.list-content .list-news .sub-news .sub-title {
+  cursor: pointer;
+}
+.list-content .list-news .sub-news .sub-title:hover {
+  text-decoration: underline;
+}
 .list-content .list-news .sub-news ul .caption {
   font-size: 14px;
   color: #879298;

--- a/css/list.css
+++ b/css/list.css
@@ -20,7 +20,7 @@
   color: #5f6e76;
 }
 
-.list-content .list-header .subscribe-btn {
+.news-section .subscribe-btn {
   border: 1px solid #d2dae0;
   border-radius: 50px;
   background-color: #f5f7f9;
@@ -32,8 +32,13 @@
   gap: 2px;
 }
 
-.list-content .list-header .subscribe-btn svg {
+.news-section .subscribe-btn svg {
   padding-top: 3px;
+}
+
+.news-section .newspaper__item .subscribe-btn {
+  display: none;
+  background-color: #ffffff;
 }
 
 .list-content .list-news {

--- a/css/list.css
+++ b/css/list.css
@@ -59,7 +59,7 @@
 }
 
 .list-content .list-news .main-news .img-container img {
-  transition: 0.5s;
+  transition: 0.3s;
 }
 
 .list-content .list-news .main-title {
@@ -84,12 +84,15 @@
   flex-wrap: wrap;
   align-content: space-between;
 }
+
 .list-content .list-news .sub-news .sub-title {
   cursor: pointer;
 }
+
 .list-content .list-news .sub-news .sub-title:hover {
   text-decoration: underline;
 }
+
 .list-content .list-news .sub-news ul .caption {
   font-size: 14px;
   color: #879298;

--- a/css/list.css
+++ b/css/list.css
@@ -81,7 +81,9 @@
   height: 100%;
   color: #4b5966;
   display: flex;
+  flex-direction: column;
   flex-wrap: wrap;
+  justify-content: space-between;
   align-content: space-between;
 }
 

--- a/css/main.css
+++ b/css/main.css
@@ -49,7 +49,8 @@
   border-left: 1px solid #d2dae0;
 }
 
-.newspaper__list .newspaper__item {
+.newspaper__list .newspaper__item,
+.blank {
   height: 96.25px;
   border-bottom: 1px solid #d2dae0;
   border-right: 1px solid #d2dae0;

--- a/css/main.css
+++ b/css/main.css
@@ -71,6 +71,14 @@
   background-color: #f5f7f9;
   cursor: pointer;
 }
+
+.newspaper__list .newspaper__item:hover img {
+  display: none;
+}
+
+.newspaper__list .newspaper__item:hover button {
+  display: inline-block;
+}
 /*  page button */
 
 .news-section {

--- a/css/main.css
+++ b/css/main.css
@@ -101,7 +101,6 @@
 }
 
 .snack-bar {
-  display: none;
   box-sizing: border-box;
   position: absolute;
   width: 286px;
@@ -113,4 +112,6 @@
   line-height: 54px;
   background-color: #4362d0;
   color: #ffffff;
+  transition: 0.5s;
+  opacity: 0;
 }

--- a/css/main.css
+++ b/css/main.css
@@ -40,6 +40,7 @@
 .news .news-navbar_content .select {
   fill: #4362d0;
 }
+
 /* newspapers section */
 .newspaper__list {
   display: grid;
@@ -54,6 +55,21 @@
   border-right: 1px solid #d2dae0;
   text-align: center;
   line-height: 96.25px;
+}
+
+.newspaper__list .newspaper__item button {
+  width: 72px;
+  height: 24px;
+  top: 36px;
+  left: 41px;
+  padding: 0px 6px 0px 6px;
+  border-radius: 50px;
+  border: 1px solid #d2dae0;
+}
+
+.newspaper__list .newspaper__item:hover {
+  background-color: #f5f7f9;
+  cursor: pointer;
 }
 /*  page button */
 

--- a/css/main.css
+++ b/css/main.css
@@ -101,6 +101,7 @@
 }
 
 .snack-bar {
+  z-index: -1;
   box-sizing: border-box;
   position: absolute;
   width: 286px;

--- a/css/main.css
+++ b/css/main.css
@@ -99,3 +99,18 @@
   left: 0;
   transform: translate(-61px, -21px);
 }
+
+.snack-bar {
+  display: none;
+  box-sizing: border-box;
+  position: absolute;
+  width: 286px;
+  height: 54px;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  text-align: center;
+  line-height: 54px;
+  background-color: #4362d0;
+  color: #ffffff;
+}

--- a/css/news.css
+++ b/css/news.css
@@ -13,13 +13,16 @@ white-space
 other text
 content
  */
+
 .categoty-nav {
   border: solid 1px #d2dae0;
   background-color: #f5f7f9;
+  overflow-y: scroll;
 }
 
 .news-container .categoty-nav .categoty-list {
   display: flex;
+  width: fit-content;
 }
 
 .news-container .categoty-nav .categoty-list .select {

--- a/css/news.css
+++ b/css/news.css
@@ -22,7 +22,7 @@ content
 
 .news-container .categoty-nav .categoty-list {
   display: flex;
-  width: fit-content;
+  width: max-content;
 }
 
 .news-container .categoty-nav .categoty-list .select {

--- a/css/news.css
+++ b/css/news.css
@@ -31,9 +31,14 @@ content
   color: #ffffff;
 }
 
+.news-container .categoty-nav .categoty-list .select:hover {
+  text-decoration: none;
+}
+
 .news-container .categoty-nav .categoty-list .select span {
   z-index: 1;
 }
+
 .news-container .categoty-nav .categoty-list .select .progress-bar {
   position: absolute;
   height: 100%;
@@ -48,4 +53,8 @@ content
   padding: 0 16px 0 16px;
   color: #879298;
   cursor: pointer;
+}
+
+.news-container .categoty-nav .categoty-list li:hover {
+  text-decoration: underline;
 }

--- a/css/reset.css
+++ b/css/reset.css
@@ -9,7 +9,6 @@ a {
 
 body {
   display: flex;
-  /* flex-direction: column; */
   align-items: center;
   justify-content: center;
   height: 100vh;

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>news stand</title>
+    <title>News Stand</title>
 
     <link rel="stylesheet" type="text/css" href="./css/index.css" />
     <link rel="stylesheet" type="text/css" href="./css/header.css" />

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 import App from "./src/App.js";
+// import json from "./listView.js";
 
 const root = document.querySelector(".root");
 new App(root, "light");

--- a/index.js
+++ b/index.js
@@ -1,5 +1,4 @@
 import App from "./src/App.js";
-// import json from "./listView.js";
 
 const root = document.querySelector(".root");
 new App(root, "light");

--- a/listView.json
+++ b/listView.json
@@ -1,0 +1,5086 @@
+{
+    "0": [
+        {
+            "materials": [
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "송정역 주차빌딩  개장 50일 곳곳 ‘하자’",
+                    "url": "http://www.gjdream.com/news/articleView.html?idxno=630698",
+                    "aid": "4fd117b5ddea74b5",
+                    "image": {
+                        "url": "https://s.pstatic.net/dthumb.phinf/?src=%22https%3A%2F%2Fs.pstatic.net%2Fstatic%2Fnewsstand%2F2023%2F0717%2Farticle_img%2Fnew_main%2F9065%2F111451_001.jpg%22&type=nf312_208&service=navermain"
+                    },
+                    "_id": "643542ba1f0f6898fc22209a"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "광주시화정청소년문화의집, 서구 화정2동과 업무협약",
+                    "url": "http://www.gjdream.com/news/articleView.html?idxno=630658",
+                    "aid": "4fd117398cf0b639",
+                    "image": null,
+                    "_id": "64783d54824d90d2cc38bd47"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "광주청소년활동진흥센터 청소년정책토론회 개최",
+                    "url": "http://www.gjdream.com/news/articleView.html?idxno=630647",
+                    "aid": "4fd117190522c259",
+                    "image": null,
+                    "_id": "64b0b0265cea28d2db2e39a3"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "“다문화가정의 행복 비법을 알려드립니다”",
+                    "url": "http://www.gjdream.com/news/articleView.html?idxno=629584",
+                    "aid": "4fc713a7e664ad27",
+                    "image": null,
+                    "_id": "64b0b0265cea28d2db2e39a4"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "[시민기자 생각]재해 복구, 행정 앞장서지만   원인자도 비용 부담해야",
+                    "url": "http://www.gjdream.com/news/articleView.html?idxno=630499",
+                    "aid": "4fd110345c8eb7f4",
+                    "image": null,
+                    "_id": "64b0b0265cea28d2db2e39a5"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "[김대원의 여의도 포커스]“할 말 못 할 바엔 정치 안하는 게 낫다”",
+                    "url": "http://www.gjdream.com/news/articleView.html?idxno=630650",
+                    "aid": "4fd11731f0749431",
+                    "image": null,
+                    "_id": "64b0b0265cea28d2db2e39a6"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "광주경총 금요포럼 ‘판소리의 멋…’",
+                    "url": "http://www.gjdream.com/news/articleView.html?idxno=630708",
+                    "aid": "4fd11a5f622e289f",
+                    "image": null,
+                    "_id": "64b0b0265cea28d2db2e39a7"
+                }
+            ],
+            "pid": "1",
+            "name": "머니투데이",
+            "logoLight": {
+                "url": "https://s.pstatic.net/static/newsstand/2020/logo/light/0604/301.png"
+            },
+            "logoDark": {
+                "url": "https://s.pstatic.net/static/newsstand/2020/logo/dark/0604/301.png"
+            },
+            "regDate": "20230717 11:10:36"
+        },
+        {
+            "materials": [
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "smartPC사랑 2023 상반기 베스트 하드웨어 어워즈 선정",
+                    "url": "https://www.ilovepc.co.kr/news/articleView.html?idxno=47208",
+                    "aid": "f1d10d514a4a5c51",
+                    "image": {
+                        "url": "https://s.pstatic.net/dthumb.phinf/?src=%22https%3A%2F%2Fs.pstatic.net%2Fstatic%2Fnewsstand%2F2023%2F0713%2Farticle_img%2Fnew_main%2F9087%2F100252_001.jpg%22&type=nf312_208&service=navermain"
+                    },
+                    "_id": "643542ba1f0f6898fc221bd1"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "가성비 게이밍 그래픽카드, 인텔 아크 A750 알아보기",
+                    "url": "https://www.ilovepc.co.kr/news/articleView.html?idxno=47112",
+                    "aid": "f1d109a9029f0be9",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc221bd2"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "2023년 7월호",
+                    "url": "http://www.ilovepc.co.kr",
+                    "aid": "167fbf961937deaa",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc221bd3"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "시원시원한 디스플레이에 휴대성까지? LG전자 2023 그램16 16ZD90RU-GX56K",
+                    "url": "https://www.ilovepc.co.kr/news/articleView.html?idxno=47218",
+                    "aid": "f1d10d70c8ab6030",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc221bd4"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "[팁] 마이크론 2400 SSD로 에이수스 로그 엘라이(ASUS ROG ALLY) 용량을 간단하게 업그레이드해보자",
+                    "url": "https://www.ilovepc.co.kr/news/articleView.html?idxno=47306",
+                    "aid": "f1d11110a25af090",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc221bd5"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "게이밍도 가능한 초경량 노트북? LG전자 2023 그램17 17Z90R-ED7VK",
+                    "url": "https://www.ilovepc.co.kr/news/articleView.html?idxno=47219",
+                    "aid": "f1d10d71166ad831",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc221bd6"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "UMPC 게임기 '옥조' 배터리 폭발 2번…휴대용 게임기 폭발 사고, 다른 제품도 있었을까?",
+                    "url": "https://www.ilovepc.co.kr/news/articleView.html?idxno=47357",
+                    "aid": "f1d111ac67ff7bec",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc221bd7"
+                }
+            ],
+            "pid": "2",
+            "name": "경향신문",
+            "logoLight": {
+                "url": "https://s.pstatic.net/static/newsstand/2020/logo/light/0604/364.png"
+            },
+            "logoDark": {
+                "url": "https://s.pstatic.net/static/newsstand/2020/logo/dark/0604/364.png"
+            },
+            "regDate": "20230713 09:58:00"
+        },
+        {
+            "materials": [
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "“아무리 싸도 억” 송지효 부모님 통영 여객선 사업 큰 손이었다(런닝맨)[어제TV]",
+                    "url": "http://news.newsen.com/news_view.php?uid=202307161856566710",
+                    "aid": "955ae1a0debf2520",
+                    "image": {
+                        "url": "https://s.pstatic.net/dthumb.phinf/?src=%22https%3A%2F%2Fs.pstatic.net%2Fstatic%2Fnewsstand%2F2023%2F0717%2Farticle_img%2Fnew_main%2F9126%2F085139_001.jpg%22&type=nf312_208&service=navermain"
+                    },
+                    "_id": "643542ba1f0f6898fc222111"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "김우빈→이찬원 폭우 피해에 ★ 기부 행렬 “도움 되기를” [종합]",
+                    "url": "http://news.newsen.com/news_view.php?uid=202307161637415710",
+                    "aid": "cffa229e4be4541e",
+                    "image": null,
+                    "_id": "64382002d2afac98f57ccef6"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "빅히트 뮤직 측 “BTS 정국 유튜브 집계 문제없다”[공식]",
+                    "url": "http://news.newsen.com/news_view.php?uid=202307170753070410",
+                    "aid": "fa821967f7653567",
+                    "image": null,
+                    "_id": "645661636e592107d2d4489a"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "강동원, 정용진 부회장 쌍둥이 남매 만나 깜짝 사인회 ‘삼촌미소’",
+                    "url": "http://news.newsen.com/news_view.php?uid=202307170702342410",
+                    "aid": "c32b29e3313554e3",
+                    "image": null,
+                    "_id": "646563463e93486eac614c31"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "“열심히 드럼 칠게요” 데이식스 도운, 성진·영케이 축하 속 만기 전역[종합]",
+                    "url": "http://news.newsen.com/news_view.php?uid=202307162034360410",
+                    "aid": "aa8593bc17e2a6fc",
+                    "image": null,
+                    "_id": "646563463e93486eac614c32"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "백진희 딸 낳았다, 안재현과 1년만 운명적 재회 (진짜가)[어제TV]",
+                    "url": "http://news.newsen.com/news_view.php?uid=202307170600231710",
+                    "aid": "c356eb24702c63a4",
+                    "image": null,
+                    "_id": "646563463e93486eac614c33"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "여자아이들 미연 ‘옅은 화장에도 예쁨 폭발’[포토엔HD]",
+                    "url": "http://news.newsen.com/news_view.php?uid=202307161853393510",
+                    "aid": "f36760832c1cb243",
+                    "image": null,
+                    "_id": "646563463e93486eac614c34"
+                }
+            ],
+            "pid": "3",
+            "name": "뉴스타파",
+            "logoLight": {
+                "url": "https://s.pstatic.net/static/newsstand/2020/logo/light/0604/447.png"
+            },
+            "logoDark": {
+                "url": "https://s.pstatic.net/static/newsstand/2020/logo/dark/0604/447.png"
+            },
+            "regDate": "20230717 08:45:34"
+        },
+        {
+            "materials": [
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "윤 대통령 \"특별재난지역 선포 등 정책 모두 동원\"",
+                    "url": "http://www.obsnews.co.kr/news/articleView.html?idxno=1406756",
+                    "aid": "20cbda31ed1c2f6f",
+                    "image": {
+                        "url": "https://s.pstatic.net/dthumb.phinf/?src=%22https%3A%2F%2Fs.pstatic.net%2Fstatic%2Fnewsstand%2F2023%2F0717%2Farticle_img%2Fnew_main%2F9070%2F104113_001.jpg%22&type=nf312_208&service=navermain"
+                    },
+                    "_id": "643542ba1f0f6898fc22219d"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "아파트 복도서 흉기 난동…1명 사망·1명 경상",
+                    "url": "http://www.obsnews.co.kr/news/articleView.html?idxno=1406750",
+                    "aid": "20cbda2b6ffefeb5",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc22219e"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "바다에 아내 빠트리고 돌 던져 살해…30대 구속영장",
+                    "url": "http://www.obsnews.co.kr/news/articleView.html?idxno=1406758",
+                    "aid": "20cbda33c17b3fad",
+                    "image": null,
+                    "_id": "64868b31c499cc07f341f2da"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "경기도·융기원·경기대·장비업체 '반도체 공유대학'",
+                    "url": "http://www.obsnews.co.kr/news/articleView.html?idxno=1406749",
+                    "aid": "20cbda15ddeb4fcb",
+                    "image": null,
+                    "_id": "64868b31c499cc07f341f2db"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "\"호우 사망·실종 48명\"…집계 외 사망자 1명 늘어",
+                    "url": "http://www.obsnews.co.kr/news/articleView.html?idxno=1406757",
+                    "aid": "20cbda32574bb78e",
+                    "image": null,
+                    "_id": "64868b31c499cc07f341f2dc"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "코레일, 경강선 세종대왕릉~여주 구간 운행 재개",
+                    "url": "http://www.obsnews.co.kr/news/articleView.html?idxno=1406730",
+                    "aid": "20cbd9edd4800eb3",
+                    "image": null,
+                    "_id": "64868b31c499cc07f341f2dd"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "국회 법사위, 오늘 '영아살해·유기 처벌강화법' 처리",
+                    "url": "http://www.obsnews.co.kr/news/articleView.html?idxno=1406727",
+                    "aid": "20cbd9d56e0d4f8b",
+                    "image": null,
+                    "_id": "64a67a2a3e93486eac6d4ead"
+                }
+            ],
+            "pid": "4",
+            "name": "오마이뉴스",
+            "logoLight": {
+                "url": "https://s.pstatic.net/static/newsstand/2020/logo/light/0604/340.png"
+            },
+            "logoDark": {
+                "url": "https://s.pstatic.net/static/newsstand/2020/logo/dark/0604/340.png"
+            },
+            "regDate": "20230717 10:37:44"
+        },
+        {
+            "materials": [
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "smartPC사랑 2023 상반기 베스트 하드웨어 어워즈 선정",
+                    "url": "https://www.ilovepc.co.kr/news/articleView.html?idxno=47208",
+                    "aid": "f1d10d514a4a5c51",
+                    "image": {
+                        "url": "https://s.pstatic.net/dthumb.phinf/?src=%22https%3A%2F%2Fs.pstatic.net%2Fstatic%2Fnewsstand%2F2023%2F0713%2Farticle_img%2Fnew_main%2F9087%2F100252_001.jpg%22&type=nf312_208&service=navermain"
+                    },
+                    "_id": "643542ba1f0f6898fc221bd1"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "가성비 게이밍 그래픽카드, 인텔 아크 A750 알아보기",
+                    "url": "https://www.ilovepc.co.kr/news/articleView.html?idxno=47112",
+                    "aid": "f1d109a9029f0be9",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc221bd2"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "2023년 7월호",
+                    "url": "http://www.ilovepc.co.kr",
+                    "aid": "167fbf961937deaa",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc221bd3"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "시원시원한 디스플레이에 휴대성까지? LG전자 2023 그램16 16ZD90RU-GX56K",
+                    "url": "https://www.ilovepc.co.kr/news/articleView.html?idxno=47218",
+                    "aid": "f1d10d70c8ab6030",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc221bd4"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "[팁] 마이크론 2400 SSD로 에이수스 로그 엘라이(ASUS ROG ALLY) 용량을 간단하게 업그레이드해보자",
+                    "url": "https://www.ilovepc.co.kr/news/articleView.html?idxno=47306",
+                    "aid": "f1d11110a25af090",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc221bd5"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "게이밍도 가능한 초경량 노트북? LG전자 2023 그램17 17Z90R-ED7VK",
+                    "url": "https://www.ilovepc.co.kr/news/articleView.html?idxno=47219",
+                    "aid": "f1d10d71166ad831",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc221bd6"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "UMPC 게임기 '옥조' 배터리 폭발 2번…휴대용 게임기 폭발 사고, 다른 제품도 있었을까?",
+                    "url": "https://www.ilovepc.co.kr/news/articleView.html?idxno=47357",
+                    "aid": "f1d111ac67ff7bec",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc221bd7"
+                }
+            ],
+            "pid": "5",
+            "name": "데일리안",
+            "logoLight": {
+                "url": "https://s.pstatic.net/static/newsstand/2020/logo/light/0604/364.png"
+            },
+            "logoDark": {
+                "url": "https://s.pstatic.net/static/newsstand/2020/logo/dark/0604/364.png"
+            },
+            "regDate": "20230713 09:58:00"
+        },
+        {
+            "materials": [
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "기록적 폭우에… 온 나라가 슬픔에 잠겼다",
+                    "url": "https://www.cctoday.co.kr/news/articleView.html?idxno=2181333",
+                    "aid": "99f490eae26eb2aa",
+                    "image": {
+                        "url": "https://s.pstatic.net/dthumb.phinf/?src=%22https%3A%2F%2Fs.pstatic.net%2Fstatic%2Fnewsstand%2F2023%2F0716%2Farticle_img%2Fnew_main%2F9063%2F183124_001.jpg%22&type=nf312_208&service=navermain"
+                    },
+                    "_id": "643542ba1f0f6898fc222149"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "충남 3곳·세종 국제화특구 지정 충청권 국제화 교육 기틀 마련 기대",
+                    "url": "https://www.cctoday.co.kr/news/articleView.html?idxno=2181137",
+                    "aid": "99f4896cb5f5b1ac",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc22214a"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "손 놓는 보건의료노조 충청지역 의료공백 불가피",
+                    "url": "https://www.cctoday.co.kr/news/articleView.html?idxno=2181057",
+                    "aid": "99f485e93c9549e9",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc22214b"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "‘지방시대위’ 세종서 출범 어디서나 살기 좋은 지방시대 구현",
+                    "url": "https://www.cctoday.co.kr/news/articleView.html?idxno=2180970",
+                    "aid": "99f4338a4c042c0a",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc22214c"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "“제발” 지하차도만 하염없이 바라보는 실종자 가족들",
+                    "url": "https://www.cctoday.co.kr/news/articleView.html?idxno=2181319",
+                    "aid": "99f490b2349888f2",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc22214d"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "집안까지 들이닥친 빗물 \"살림살이 둥둥 떠다녀\"",
+                    "url": "https://www.cctoday.co.kr/news/articleView.html?idxno=2181330",
+                    "aid": "99f490e74f2a3f67",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc22214e"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "여야 지도부, 폭우 피해 입은 충북 방문 복구 지원 약속",
+                    "url": "https://www.cctoday.co.kr/news/articleView.html?idxno=2181316",
+                    "aid": "99f490afa15415af",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc22214f"
+                }
+            ],
+            "pid": "6",
+            "name": "스포츠서울",
+            "logoLight": {
+                "url": "https://s.pstatic.net/static/newsstand/2020/logo/light/0604/331.png"
+            },
+            "logoDark": {
+                "url": "https://s.pstatic.net/static/newsstand/2020/logo/dark/0604/331.png"
+            },
+            "regDate": "20230716 18:27:01"
+        },
+        {
+            "materials": [
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "최대 200㎜ 물폭탄… 침수·산사태 위험지 수백명 긴급 대피",
+                    "url": "http://www.knnews.co.kr/news/articleView.php?idxno=1409013",
+                    "aid": "bf2851f8824cf908",
+                    "image": {
+                        "url": "https://s.pstatic.net/dthumb.phinf/?src=%22https%3A%2F%2Fs.pstatic.net%2Fstatic%2Fnewsstand%2F2023%2F0717%2Farticle_img%2Fnew_main%2F9072%2F110825_001.jpg%22&type=nf312_208&service=navermain"
+                    },
+                    "_id": "643542ba1f0f6898fc222157"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "도내 침수 취약주택 30% “비용 부담돼 물막이판 설치 안 해”",
+                    "url": "http://www.knnews.co.kr/news/articleView.php?idxno=1409021",
+                    "aid": "bf285215791a758b",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc222158"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "창녕함안보 등 4대강 보 정책 ‘해체’서 ‘존치’로 바뀔 듯",
+                    "url": "http://www.knnews.co.kr/news/articleView.php?idxno=1409016",
+                    "aid": "bf2851fbfd7004a5",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc222159"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "지리산 인근 지자체 ‘케이블카 재추진’ 시끌",
+                    "url": "http://www.knnews.co.kr/news/articleView.php?idxno=1409000",
+                    "aid": "bf2851d6139a692a",
+                    "image": null,
+                    "_id": "64713b656e592107d2d9ae55"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "오염수 우려에 손님 줄었는데 장마까지… 어시장 상인 시름",
+                    "url": "http://www.knnews.co.kr/news/articleView.php?idxno=1409011",
+                    "aid": "bf2851f6858af14a",
+                    "image": null,
+                    "_id": "64997f72530d8014e0f35b08"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "보건의료노조 총파업 종료… 양산부산대병원은 파업 계속",
+                    "url": "http://www.knnews.co.kr/news/articleView.php?idxno=1409018",
+                    "aid": "bf2851fdfa320c63",
+                    "image": null,
+                    "_id": "64997f72530d8014e0f35b09"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "경남도의회 “경남TP 원장 후보 ‘유흥접대 전력’ 있을 수 있는 일”",
+                    "url": "http://www.knnews.co.kr/news/articleView.php?idxno=1409022",
+                    "aid": "bf285216f77b796a",
+                    "image": null,
+                    "_id": "64997f72530d8014e0f35b0a"
+                }
+            ],
+            "pid": "7",
+            "name": "스포츠동아",
+            "logoLight": {
+                "url": "https://s.pstatic.net/static/newsstand/2020/logo/light/0604/333.png"
+            },
+            "logoDark": {
+                "url": "https://s.pstatic.net/static/newsstand/2020/logo/dark/0604/333.png"
+            },
+            "regDate": "20230717 11:01:04"
+        },
+        {
+            "materials": [
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "엄정화·김완선·이효리…화사는 '언니'들이 지킨다",
+                    "url": "http://www.sportsworldi.com/newsView/20230717506063",
+                    "aid": "4fe028c2cf60f142",
+                    "image": {
+                        "url": "https://s.pstatic.net/dthumb.phinf/?src=%22https%3A%2F%2Fs.pstatic.net%2Fstatic%2Fnewsstand%2F2023%2F0717%2Farticle_img%2Fnew_main%2F9120%2F103430_001.jpg%22&type=nf312_208&service=navermain"
+                    },
+                    "_id": "643542ba1f0f6898fc221e6a"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "김민재 뮌헨행 공식 발표만 남았다",
+                    "url": "http://www.sportsworldi.com/newsView/20230716509459",
+                    "aid": "1afb59895fbb8789",
+                    "image": null,
+                    "_id": "649673e740d2947ae427e960"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "'알카라스의 시대' 증명한 윔블던 우승",
+                    "url": "http://www.sportsworldi.com/newsView/20230717505052",
+                    "aid": "4fdfb4438e7b16c3",
+                    "image": null,
+                    "_id": "649673e740d2947ae427e961"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "‘킹더랜드’ 이준호♥임윤아, 달빛 입맞춤",
+                    "url": "http://www.sportsworldi.com/newsView/20230717505503",
+                    "aid": "4fdfc66e7ca52bae",
+                    "image": null,
+                    "_id": "649673e740d2947ae427e962"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "송지효 \"부모님, 통영서 여객선 사업해\"",
+                    "url": "http://www.sportsworldi.com/newsView/20230716516433",
+                    "aid": "1b0813a9babee169",
+                    "image": null,
+                    "_id": "649673e740d2947ae427e963"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "한효주·박나래, '수해 복구' 기부 행렬 동참",
+                    "url": "http://www.sportsworldi.com/newsView/20230717507040",
+                    "aid": "4fe09ce07653af20",
+                    "image": null,
+                    "_id": "649673e740d2947ae427e964"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "김종민, “코요태 리더, 신지가 시켜서 해”",
+                    "url": "http://www.sportsworldi.com/newsView/20230716516851",
+                    "aid": "1b0822e91754ca29",
+                    "image": null,
+                    "_id": "649673e740d2947ae427e965"
+                }
+            ],
+            "pid": "8",
+            "name": "문화일보",
+            "logoLight": {
+                "url": "https://s.pstatic.net/static/newsstand/2020/logo/light/0604/396.png"
+            },
+            "logoDark": {
+                "url": "https://s.pstatic.net/static/newsstand/2020/logo/dark/0604/396.png"
+            },
+            "regDate": "20230717 10:27:57"
+        },
+        {
+            "materials": [
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "[단독] 국교위, 전교조 추천 국교위원 '거부'…...",
+                    "url": "https://home.ebs.co.kr/ebsnews/menu1/newsAllView/60371726/N?eduNewsYn=N",
+                    "aid": "63b436be78a97cbe",
+                    "image": {
+                        "url": "https://s.pstatic.net/dthumb.phinf/?src=%22https%3A%2F%2Fs.pstatic.net%2Fstatic%2Fnewsstand%2F2023%2F0717%2Farticle_img%2Fnew_main%2F9076%2F104306_001.png%22&type=nf312_208&service=navermain"
+                    },
+                    "_id": "643542ba1f0f6898fc2221a4"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "영아 유기·살해 확인 계속…후속 입법 속도",
+                    "url": "https://home.ebs.co.kr/ebsnews/menu1/newsAllView/60371727/N?eduNewsYn=N",
+                    "aid": "bd8fa0ff6c3900ff",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc2221a5"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "<뉴스브릿지> 계약 종료 후 '이름' 잃는 가수들…분쟁 원인과 해결책은",
+                    "url": "https://home.ebs.co.kr/ebsnews/menu1/newsAllView/60371728/N?eduNewsYn=N",
+                    "aid": "176b0b405fc88540",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc2221a6"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "[단독] 반수생 급증 현실화되나…9월 모평 학원 응시생 전년比 1,536명↑",
+                    "url": "https://home.ebs.co.kr/ebsnews/menu1/newsAllView/60371690/N?eduNewsYn=N",
+                    "aid": "22e2ec50168bd010",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc2221a7"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "어린이집‧유치원 대기 인원 한눈에…통합정보 개편",
+                    "url": "https://home.ebs.co.kr/ebsnews/menu1/newsAllView/60371691/N?eduNewsYn=N",
+                    "aid": "7cbe56910a1b5451",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc2221a8"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "영아살해 '솜방망이' 개선…70년만 형법 개정 추진",
+                    "url": "https://home.ebs.co.kr/ebsnews/menu1/newsAllView/60371692/N?eduNewsYn=N",
+                    "aid": "d699c0d2fdaad892",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc2221a9"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "'4세대 나이스' 불편 이어져…안정화 과제는?",
+                    "url": "https://home.ebs.co.kr/ebsnews/menu1/newsAllView/60371410/N?eduNewsYn=N",
+                    "aid": "75004156ad1216",
+                    "image": null,
+                    "_id": "64a69d1558a9ce6eb3c6d2e8"
+                }
+            ],
+            "pid": "9",
+            "name": "KBS World",
+            "logoLight": {
+                "url": "https://s.pstatic.net/static/newsstand/up/2020/0803/nsd20247547.png"
+            },
+            "logoDark": {
+                "url": "https://s.pstatic.net/static/newsstand/up/2020/0803/nsd202358800.png"
+            },
+            "regDate": "20230717 10:35:16"
+        }
+    ],
+    "1": [
+        {
+            "materials": [
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "오송 지하차도 교통통제 왜 안했나... 사망자 계속 늘어",
+                    "url": "http://www.womennews.co.kr/news/articleView.html?idxno=238458",
+                    "aid": "bba8a21b6f082e9b",
+                    "image": {
+                        "url": "https://s.pstatic.net/dthumb.phinf/?src=%22https%3A%2F%2Fs.pstatic.net%2Fstatic%2Fnewsstand%2F2023%2F0717%2Farticle_img%2Fnew_main%2F9053%2F111451_001.jpg%22&type=nf312_208&service=navermain"
+                    },
+                    "_id": "643542ba1f0f6898fc2220af"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "오송 침수 지하차도 사망자 7명…5명은 버스 탑승객",
+                    "url": "http://www.womennews.co.kr/news/articleView.html?idxno=238452",
+                    "aid": "bba8a215487f4815",
+                    "image": null,
+                    "_id": "64a084d762e82fd2bec3dfb0"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "윤 대통령, 우크라이나 방문… 젤렌스키와 정상회담",
+                    "url": "http://www.womennews.co.kr/news/articleView.html?idxno=238450",
+                    "aid": "bba8a21390fc5093",
+                    "image": null,
+                    "_id": "64a084d762e82fd2bec3dfb1"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "52세에 대학 간 엄마와 페미니스트 딸 : 작가일 인스타툰",
+                    "url": "http://www.womennews.co.kr/news/articleView.html?idxno=238264",
+                    "aid": "bba89ab4ceb2d7b4",
+                    "image": null,
+                    "_id": "64a084d762e82fd2bec3dfb2"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "[날씨] 충청권 시간당  30~60mm 폭우...내일까지 최고 300mm 이상",
+                    "url": "http://www.womennews.co.kr/news/articleView.html?idxno=238440",
+                    "aid": "bba8a1f426ccc874",
+                    "image": null,
+                    "_id": "64a084d762e82fd2bec3dfb3"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "“대기업 사외이사, ‘법조계 서육남’ 편중… 기업 지배구조 다양성 부족”",
+                    "url": "http://www.womennews.co.kr/news/articleView.html?idxno=238394",
+                    "aid": "bba89ed25b00e812",
+                    "image": null,
+                    "_id": "64ae9be1c499cc07f349e0fc"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "“‘불체포특권’ 포기하겠습니다” 민주당 의원 31명 선언",
+                    "url": "http://www.womennews.co.kr/news/articleView.html?idxno=238429",
+                    "aid": "bba8a1bf0c3b11ff",
+                    "image": null,
+                    "_id": "64b2dfd57dd28a7aefc56774"
+                }
+            ],
+            "pid": "10",
+            "name": "한국중앙데일리",
+            "logoLight": {
+                "url": "https://s.pstatic.net/static/newsstand/2020/logo/light/0604/310.png"
+            },
+            "logoDark": {
+                "url": "https://s.pstatic.net/static/newsstand/2020/logo/dark/0604/310.png"
+            },
+            "regDate": "20230717 11:10:03"
+        },
+        {
+            "materials": [
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "학교 신설, 특수교육원, 폐교, IB까지 지금 제주도교육청은 온통 ‘용역 중’",
+                    "url": "http://www.jejusori.net/news/articleView.html?idxno=417186",
+                    "aid": "864950ea3ed26bd6",
+                    "image": {
+                        "url": "https://s.pstatic.net/dthumb.phinf/?src=%22https%3A%2F%2Fs.pstatic.net%2Fstatic%2Fnewsstand%2F2023%2F0717%2Farticle_img%2Fnew_main%2F9073%2F104306_001.jpg%22&type=nf312_208&service=navermain"
+                    },
+                    "_id": "643542ba1f0f6898fc222165"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "“일본 원전 오염수 해양 방류 저지 우리 세대의 무조건적인 의무이자 책임”",
+                    "url": "http://www.jejusori.net/news/articleView.html?idxno=417190",
+                    "aid": "864951033c1bd8dd",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc222166"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "가칭 제주예술인회관, ‘지역에 꼭 필요한 예술공간’ 추진 탄력받을까?",
+                    "url": "http://www.jejusori.net/news/articleView.html?idxno=417195",
+                    "aid": "86495108b400ec38",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc222167"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "취임 1년 오영훈 제주지사-김광수 제주교육감 긍정 평가 ‘동반 하락’",
+                    "url": "http://www.jejusori.net/news/articleView.html?idxno=417180",
+                    "aid": "864950e4488c549c",
+                    "image": null,
+                    "_id": "6445133d1f0f6898fc24ddc1"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "“여름 휴가는 푸파페 제주로!” 농촌융복합 체험행사 풍성",
+                    "url": "http://www.jejusori.net/news/articleView.html?idxno=417191",
+                    "aid": "86495104ba7cdcbc",
+                    "image": null,
+                    "_id": "6445133d1f0f6898fc24ddc2"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "아픈 몸의 현상학 / 황임경",
+                    "url": "http://www.jejusori.net/news/articleView.html?idxno=417201",
+                    "aid": "864953aebeafa612",
+                    "image": null,
+                    "_id": "6445133d1f0f6898fc24ddc3"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "제주 로얄쇼핑 천장 붕괴 원인은?...‘부실공사-시설 노후화’ 의견 분분",
+                    "url": "http://www.jejusori.net/news/articleView.html?idxno=416855",
+                    "aid": "8648f6743902480c",
+                    "image": null,
+                    "_id": "6445133d1f0f6898fc24ddc4"
+                }
+            ],
+            "pid": "11",
+            "name": "인사이트",
+            "logoLight": {
+                "url": "https://s.pstatic.net/static/newsstand/2020/logo/light/0604/334.png"
+            },
+            "logoDark": {
+                "url": "https://s.pstatic.net/static/newsstand/2020/logo/dark/0604/334.png"
+            },
+            "regDate": "20230717 10:33:59"
+        },
+        {
+            "materials": [
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "<마당이 있는 집> 원작자 김진영 인터뷰",
+                    "url": "https://ch.yes24.com/Article/View/54599?y_contents=채널예스&y_channel=뉴스캐스트&y_area=61",
+                    "aid": "7737d4728b170632",
+                    "image": {
+                        "url": "https://s.pstatic.net/dthumb.phinf/?src=%22https%3A%2F%2Fs.pstatic.net%2Fstatic%2Fnewsstand%2F2023%2F0717%2Farticle_img%2Fnew_main%2F9084%2F111451_001.jpg%22&type=nf312_208&service=navermain"
+                    },
+                    "_id": "643542ba1f0f6898fc221ba7"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "What's in my cart? 책 장바구니 특집!",
+                    "url": "https://ch.yes24.com/Article/View/54595?y_contents=채널예스&y_channel=뉴스캐스트&y_area=61",
+                    "aid": "e232196e2093fc2e",
+                    "image": null,
+                    "_id": "648049361f0f6898fc301cae"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "삶이 우울하거나 지겨우면 이 작품을 보라!",
+                    "url": "https://ch.yes24.com/Article/View/54591?y_contents=채널예스&y_channel=뉴스캐스트&y_area=61",
+                    "aid": "4d2c5e6ab610f22a",
+                    "image": null,
+                    "_id": "64b4a4a660f3c014e7afd1a6"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "뮤지컬 <신의 손가락> - 모두의 인생은 한 편의 동화다",
+                    "url": "https://ch.yes24.com/Article/View/54583?y_contents=채널예스&y_channel=뉴스캐스트&y_area=61",
+                    "aid": "54c2d28d28660dcd",
+                    "image": null,
+                    "_id": "64b4a4a660f3c014e7afd1a7"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "예술가들이 매혹된 색채를 찾아 떠나는 프로방스 여행",
+                    "url": "https://ch.yes24.com/Article/View/54603?y_contents=채널예스&y_channel=뉴스캐스트&y_area=61",
+                    "aid": "d8004a16f6443196",
+                    "image": null,
+                    "_id": "64b4a4a660f3c014e7afd1a8"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "[김소미의 혼자 영화관에 갔어] 외로운 방조자들의 우주 - <스파이더맨 : 어크로스 더 유니버스>",
+                    "url": "https://ch.yes24.com/Article/View/54602?y_contents=채널예스&y_channel=뉴스캐스트&y_area=61",
+                    "aid": "f2bedb555ba36f15",
+                    "image": null,
+                    "_id": "64b4a4a660f3c014e7afd1a9"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "[임진아의 카페 생활] 여름 방학 기분 - 커먼마치",
+                    "url": "https://ch.yes24.com/Article/View/54600?y_contents=채널예스&y_channel=뉴스캐스트&y_area=61",
+                    "aid": "283bfdd32661ea13",
+                    "image": null,
+                    "_id": "64b4a4a660f3c014e7afd1aa"
+                }
+            ],
+            "pid": "12",
+            "name": "법률방송뉴스",
+            "logoLight": {
+                "url": "https://s.pstatic.net/static/newsstand/up/2023/0418/nsd124959421.png"
+            },
+            "logoDark": {
+                "url": "https://s.pstatic.net/static/newsstand/up/2023/0418/nsd124945796.png"
+            },
+            "regDate": "20230717 11:10:46"
+        },
+        {
+            "materials": [
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "Heavy Monsoon Rains Leave at Least 39 Dead",
+                    "url": "http://world.kbs.co.kr/service/news_view.htm?lang=e&id=Dm&Seq_Code=179159",
+                    "aid": "2f121de9023158e9",
+                    "image": {
+                        "url": "https://s.pstatic.net/dthumb.phinf/?src=%22https%3A%2F%2Fs.pstatic.net%2Fstatic%2Fnewsstand%2F2023%2F0717%2Farticle_img%2Fnew_main%2F9057%2F105536_001.jpg%22&type=nf312_208&service=navermain"
+                    },
+                    "_id": "643542ba1f0f6898fc22210a"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "Heavy Rains to Continue in Chungcheong, Southern Regions",
+                    "url": "http://world.kbs.co.kr/service/news_view.htm?lang=e&id=Sc&Seq_Code=179161",
+                    "aid": "8cfbb1c70df8f847",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc22210b"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "Yoon Returns from Trip to Lithuania, Poland, Ukraine",
+                    "url": "http://world.kbs.co.kr/service/news_view.htm?lang=e&id=Po&Seq_Code=179160",
+                    "aid": "073c7375b4cefa35",
+                    "image": null,
+                    "_id": "646310e67dd28a7aefb5ecd2"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "韩暴雨导致39人死亡、9人失踪 逾万人紧急避难",
+                    "url": "http://world.kbs.co.kr/service/news_view.htm?lang=c&id=Dm&Seq_Code=80012",
+                    "aid": "4faf4b34d06dfdcc",
+                    "image": null,
+                    "_id": "64a52ac333520e07dac01d0b"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "尹锡悦主持召开暴雨有关会议 朝野就指定灾难地区形成共识",
+                    "url": "http://world.kbs.co.kr/service/news_view.htm?lang=c&id=Po&Seq_Code=80014",
+                    "aid": "dac96f00dc7ce500",
+                    "image": null,
+                    "_id": "64a52ac333520e07dac01d0c"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "韓国各地で豪雨 40人死亡 9人行方不明",
+                    "url": "http://world.kbs.co.kr/service/news_view.htm?lang=j&id=Dm&Seq_Code=85980",
+                    "aid": "fd59ce08547d38",
+                    "image": null,
+                    "_id": "64a52ac333520e07dac01d0d"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "ソウルの人口減少率 全国で最高",
+                    "url": "http://world.kbs.co.kr/service/news_view.htm?lang=j&id=Dm&Seq_Code=85985",
+                    "aid": "fd59ce0d7d5b1553",
+                    "image": null,
+                    "_id": "64aba8f758a9ce6eb3c7c619"
+                }
+            ],
+            "pid": "13",
+            "name": "시사저널",
+            "logoLight": {
+                "url": "https://s.pstatic.net/static/newsstand/2020/logo/light/0604/326.png"
+            },
+            "logoDark": {
+                "url": "https://s.pstatic.net/static/newsstand/2020/logo/dark/0604/326.png"
+            },
+            "regDate": "20230717 10:53:42"
+        },
+        {
+            "materials": [
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "Heavy Monsoon Rains Leave at Least 39 Dead",
+                    "url": "http://world.kbs.co.kr/service/news_view.htm?lang=e&id=Dm&Seq_Code=179159",
+                    "aid": "2f121de9023158e9",
+                    "image": {
+                        "url": "https://s.pstatic.net/dthumb.phinf/?src=%22https%3A%2F%2Fs.pstatic.net%2Fstatic%2Fnewsstand%2F2023%2F0717%2Farticle_img%2Fnew_main%2F9057%2F105536_001.jpg%22&type=nf312_208&service=navermain"
+                    },
+                    "_id": "643542ba1f0f6898fc22210a"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "Heavy Rains to Continue in Chungcheong, Southern Regions",
+                    "url": "http://world.kbs.co.kr/service/news_view.htm?lang=e&id=Sc&Seq_Code=179161",
+                    "aid": "8cfbb1c70df8f847",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc22210b"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "Yoon Returns from Trip to Lithuania, Poland, Ukraine",
+                    "url": "http://world.kbs.co.kr/service/news_view.htm?lang=e&id=Po&Seq_Code=179160",
+                    "aid": "073c7375b4cefa35",
+                    "image": null,
+                    "_id": "646310e67dd28a7aefb5ecd2"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "韩暴雨导致39人死亡、9人失踪 逾万人紧急避难",
+                    "url": "http://world.kbs.co.kr/service/news_view.htm?lang=c&id=Dm&Seq_Code=80012",
+                    "aid": "4faf4b34d06dfdcc",
+                    "image": null,
+                    "_id": "64a52ac333520e07dac01d0b"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "尹锡悦主持召开暴雨有关会议 朝野就指定灾难地区形成共识",
+                    "url": "http://world.kbs.co.kr/service/news_view.htm?lang=c&id=Po&Seq_Code=80014",
+                    "aid": "dac96f00dc7ce500",
+                    "image": null,
+                    "_id": "64a52ac333520e07dac01d0c"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "韓国各地で豪雨 40人死亡 9人行方不明",
+                    "url": "http://world.kbs.co.kr/service/news_view.htm?lang=j&id=Dm&Seq_Code=85980",
+                    "aid": "fd59ce08547d38",
+                    "image": null,
+                    "_id": "64a52ac333520e07dac01d0d"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "ソウルの人口減少率 全国で最高",
+                    "url": "http://world.kbs.co.kr/service/news_view.htm?lang=j&id=Dm&Seq_Code=85985",
+                    "aid": "fd59ce0d7d5b1553",
+                    "image": null,
+                    "_id": "64aba8f758a9ce6eb3c7c619"
+                }
+            ],
+            "pid": "14",
+            "name": "조이뉴스",
+            "logoLight": {
+                "url": "https://s.pstatic.net/static/newsstand/2020/logo/light/0604/326.png"
+            },
+            "logoDark": {
+                "url": "https://s.pstatic.net/static/newsstand/2020/logo/dark/0604/326.png"
+            },
+            "regDate": "20230717 10:53:42"
+        },
+        {
+            "materials": [
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "제주도, 노후 차집관로 2026년까지 전면 교체",
+                    "url": "http://www.jejudomin.co.kr/news/articleView.html?idxno=218066",
+                    "aid": "16dfd360b7561820",
+                    "image": {
+                        "url": "https://s.pstatic.net/dthumb.phinf/?src=%22https%3A%2F%2Fs.pstatic.net%2Fstatic%2Fnewsstand%2F2023%2F0717%2Farticle_img%2Fnew_main%2F9099%2F111451_001.jpg%22&type=nf312_208&service=navermain"
+                    },
+                    "_id": "643542ba1f0f6898fc221db4"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "제주도의회, 강경흠 의원 징계 착수…사퇴 요구 잇따라",
+                    "url": "http://www.jejudomin.co.kr/news/articleView.html?idxno=218046",
+                    "aid": "16dfd322e2f707e2",
+                    "image": null,
+                    "_id": "64af13a4548a597b72d3604a"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "제주도 ‘공공주도 2.0 풍력 조례’ 의회서 ‘제동’",
+                    "url": "http://www.jejudomin.co.kr/news/articleView.html?idxno=218022",
+                    "aid": "16dfd2e09f9208a0",
+                    "image": null,
+                    "_id": "64af13a4548a597b72d3604b"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "제주 자원순환사회 조성 핵심기반시설 본격 가동",
+                    "url": "http://www.jejudomin.co.kr/news/articleView.html?idxno=218057",
+                    "aid": "16dfd34228e80bc2",
+                    "image": null,
+                    "_id": "64b02a1363b70c6ebed54bff"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "양파·당근 과잉생산 우려...10% 이상 감축 필요",
+                    "url": "http://www.jejudomin.co.kr/news/articleView.html?idxno=218055",
+                    "aid": "16dfd34071651440",
+                    "image": null,
+                    "_id": "64b14b113c50cd9912fcde86"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "제주, 동물등록 8.7% 늘고↑...유기동물 11.8% 감소↓",
+                    "url": "http://www.jejudomin.co.kr/news/articleView.html?idxno=218054",
+                    "aid": "16dfd33f95a3987f",
+                    "image": null,
+                    "_id": "64b14b113c50cd9912fcde87"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "제주 마을관광 브랜드 ‘카름스테이’ 3곳 신규 선정",
+                    "url": "http://www.jejudomin.co.kr/news/articleView.html?idxno=218045",
+                    "aid": "16dfd32107358c21",
+                    "image": null,
+                    "_id": "64b284a8e82d6f14f22b4cc4"
+                }
+            ],
+            "pid": "15",
+            "name": "헤럴드경제",
+            "logoLight": {
+                "url": "https://s.pstatic.net/static/newsstand/2020/logo/light/0604/389.png"
+            },
+            "logoDark": {
+                "url": "https://s.pstatic.net/static/newsstand/2020/logo/dark/0604/389.png"
+            },
+            "regDate": "20230717 11:10:38"
+        },
+        {
+            "materials": [
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "<마당이 있는 집> 원작자 김진영 인터뷰",
+                    "url": "https://ch.yes24.com/Article/View/54599?y_contents=채널예스&y_channel=뉴스캐스트&y_area=61",
+                    "aid": "7737d4728b170632",
+                    "image": {
+                        "url": "https://s.pstatic.net/dthumb.phinf/?src=%22https%3A%2F%2Fs.pstatic.net%2Fstatic%2Fnewsstand%2F2023%2F0717%2Farticle_img%2Fnew_main%2F9084%2F111451_001.jpg%22&type=nf312_208&service=navermain"
+                    },
+                    "_id": "643542ba1f0f6898fc221ba7"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "What's in my cart? 책 장바구니 특집!",
+                    "url": "https://ch.yes24.com/Article/View/54595?y_contents=채널예스&y_channel=뉴스캐스트&y_area=61",
+                    "aid": "e232196e2093fc2e",
+                    "image": null,
+                    "_id": "648049361f0f6898fc301cae"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "삶이 우울하거나 지겨우면 이 작품을 보라!",
+                    "url": "https://ch.yes24.com/Article/View/54591?y_contents=채널예스&y_channel=뉴스캐스트&y_area=61",
+                    "aid": "4d2c5e6ab610f22a",
+                    "image": null,
+                    "_id": "64b4a4a660f3c014e7afd1a6"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "뮤지컬 <신의 손가락> - 모두의 인생은 한 편의 동화다",
+                    "url": "https://ch.yes24.com/Article/View/54583?y_contents=채널예스&y_channel=뉴스캐스트&y_area=61",
+                    "aid": "54c2d28d28660dcd",
+                    "image": null,
+                    "_id": "64b4a4a660f3c014e7afd1a7"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "예술가들이 매혹된 색채를 찾아 떠나는 프로방스 여행",
+                    "url": "https://ch.yes24.com/Article/View/54603?y_contents=채널예스&y_channel=뉴스캐스트&y_area=61",
+                    "aid": "d8004a16f6443196",
+                    "image": null,
+                    "_id": "64b4a4a660f3c014e7afd1a8"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "[김소미의 혼자 영화관에 갔어] 외로운 방조자들의 우주 - <스파이더맨 : 어크로스 더 유니버스>",
+                    "url": "https://ch.yes24.com/Article/View/54602?y_contents=채널예스&y_channel=뉴스캐스트&y_area=61",
+                    "aid": "f2bedb555ba36f15",
+                    "image": null,
+                    "_id": "64b4a4a660f3c014e7afd1a9"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "[임진아의 카페 생활] 여름 방학 기분 - 커먼마치",
+                    "url": "https://ch.yes24.com/Article/View/54600?y_contents=채널예스&y_channel=뉴스캐스트&y_area=61",
+                    "aid": "283bfdd32661ea13",
+                    "image": null,
+                    "_id": "64b4a4a660f3c014e7afd1aa"
+                }
+            ],
+            "pid": "16",
+            "name": "에너지경제",
+            "logoLight": {
+                "url": "https://s.pstatic.net/static/newsstand/up/2023/0418/nsd124959421.png"
+            },
+            "logoDark": {
+                "url": "https://s.pstatic.net/static/newsstand/up/2023/0418/nsd124945796.png"
+            },
+            "regDate": "20230717 11:10:46"
+        }
+    ],
+    "2": [
+        {
+            "materials": [
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "해변의 양탄자, 비치타올",
+                    "url": "https://www.elle.co.kr/article/79048",
+                    "aid": "7bd1cdfaa2f52406",
+                    "image": {
+                        "url": "https://s.pstatic.net/dthumb.phinf/?src=%22https%3A%2F%2Fs.pstatic.net%2Fstatic%2Fnewsstand%2F2023%2F0717%2Farticle_img%2Fnew_main%2F9080%2F104113_001.jpg%22&type=nf312_208&service=navermain"
+                    },
+                    "_id": "643542ba1f0f6898fc221b53"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "패션 디자이너 지나 손의 로스엔젤레스 #집업실",
+                    "url": "https://www.elle.co.kr/article/79116",
+                    "aid": "7bd1d15c456829a4",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc221b54"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "마지막 순간까지 예술과 함께 했던 제인 버킨이 세상을 떠났다",
+                    "url": "https://www.elle.co.kr/article/79200",
+                    "aid": "7bd1d4f8e386b0c8",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc221b55"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "지니(JINI)와 글로벌 메이크업 브랜드 M∙A∙C이 만났다",
+                    "url": "https://www.elle.co.kr/article/79189",
+                    "aid": "7bd1d23833f8f608",
+                    "image": null,
+                    "_id": "64952266e9bedeca6226220d"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "김우빈-신민아, 가장 먼저 수해 이웃 돕기 나선 기부 커플",
+                    "url": "https://www.elle.co.kr/article/79197",
+                    "aid": "7bd1d255b1ceb6cb",
+                    "image": null,
+                    "_id": "64952266e9bedeca6226220e"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "장마철을 현명하게 이겨낼 채정안의 장마 아이템 7",
+                    "url": "https://www.elle.co.kr/article/79196",
+                    "aid": "7bd1d254aa6981ac",
+                    "image": null,
+                    "_id": "64a1c4c40123ecca7c84ff5c"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "‘발리댁’ 가희가 알려주는 발리 여행 Tip",
+                    "url": "https://www.elle.co.kr/article/79190",
+                    "aid": "7bd1d24e7e0a42f2",
+                    "image": null,
+                    "_id": "64a323283e93486eac6c92ec"
+                }
+            ],
+            "pid": "17",
+            "name": "비즈니스포스트",
+            "logoLight": {
+                "url": "https://s.pstatic.net/static/newsstand/2020/logo/light/0604/354.png"
+            },
+            "logoDark": {
+                "url": "https://s.pstatic.net/static/newsstand/2020/logo/dark/0604/354.png"
+            },
+            "regDate": "20230717 10:00:00"
+        },
+        {
+            "materials": [
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "\"환상적이었다\" 류현진 KKKKK에 美 호평…'144.5㎞+66구' 다 완벽했다",
+                    "url": "https://www.spotvnews.co.kr/news/articleView.html?idxno=620598",
+                    "aid": "7a8ee490d539a3f0",
+                    "image": {
+                        "url": "https://s.pstatic.net/dthumb.phinf/?src=%22https%3A%2F%2Fs.pstatic.net%2Fstatic%2Fnewsstand%2F2023%2F0717%2Farticle_img%2Fnew_main%2F9200%2F111451_001.jpg%22&type=nf312_208&service=navermain"
+                    },
+                    "_id": "643542ba1f0f6898fc221b68"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "\"빅리그 복귀 가까워져\"…류현진, '5이닝 5K 1실점' 트리플A에서도 강력했다",
+                    "url": "https://www.spotvnews.co.kr/news/articleView.html?idxno=620575",
+                    "aid": "7a8ee44f486cb751",
+                    "image": null,
+                    "_id": "64a7c11b052e097ad98f0e8e"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "'최초·유일 김용희 앞에서 채은성 만루포+문동주 158.7㎞ 쾅!' 나눔 올스타 2년 연속 웃었다…클로저 고우석, 타자 뷰캐넌에 진땀[올스타 게임노트]",
+                    "url": "https://www.spotvnews.co.kr/news/articleView.html?idxno=620496",
+                    "aid": "7a8ee0cd322e2313",
+                    "image": null,
+                    "_id": "64a7c11b052e097ad98f0e8f"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "'손가락 부상 후유증' 오타니, 멀티히트에도 5이닝 5실점 '시즌 5패'",
+                    "url": "https://www.spotvnews.co.kr/news/articleView.html?idxno=620363",
+                    "aid": "7a8edcac5f703294",
+                    "image": null,
+                    "_id": "64a7c11b052e097ad98f0e90"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "'나 MVP 아니야?' 무관의 뷰캐넌, 호명 안 했는데 시상대 '항의 방문'",
+                    "url": "https://www.spotvnews.co.kr/news/articleView.html?idxno=620663",
+                    "aid": "7a8ee7ef9dfecaf1",
+                    "image": null,
+                    "_id": "64a7c11b052e097ad98f0e91"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "손흥민과 얼마나 닮았나…호주 팬들 벽화까지 그리며 프리시즌 반겼다",
+                    "url": "https://www.spotvnews.co.kr/news/articleView.html?idxno=620646",
+                    "aid": "7a8ee7b4bbc5c88c",
+                    "image": null,
+                    "_id": "64a7c11b052e097ad98f0e92"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "[윔블던 결산] '빅3 시대' 마침표 찍은 알카라스, 새로운 'GOAT' 가능할까",
+                    "url": "https://www.spotvnews.co.kr/news/articleView.html?idxno=620676",
+                    "aid": "7a8ee8114f0a3bcf",
+                    "image": null,
+                    "_id": "64b13f1c58a9ce6eb3c90728"
+                }
+            ],
+            "pid": "18",
+            "name": "스코어데일리",
+            "logoLight": {
+                "url": "https://s.pstatic.net/static/newsstand/up/2021/1130/nsd10159718.png"
+            },
+            "logoDark": {
+                "url": "https://s.pstatic.net/static/newsstand/up/2021/1130/nsd101536636.png"
+            },
+            "regDate": "20230717 11:10:10"
+        },
+        {
+            "materials": [
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "학교 신설, 특수교육원, 폐교, IB까지 지금 제주도교육청은 온통 ‘용역 중’",
+                    "url": "http://www.jejusori.net/news/articleView.html?idxno=417186",
+                    "aid": "864950ea3ed26bd6",
+                    "image": {
+                        "url": "https://s.pstatic.net/dthumb.phinf/?src=%22https%3A%2F%2Fs.pstatic.net%2Fstatic%2Fnewsstand%2F2023%2F0717%2Farticle_img%2Fnew_main%2F9073%2F104306_001.jpg%22&type=nf312_208&service=navermain"
+                    },
+                    "_id": "643542ba1f0f6898fc222165"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "“일본 원전 오염수 해양 방류 저지 우리 세대의 무조건적인 의무이자 책임”",
+                    "url": "http://www.jejusori.net/news/articleView.html?idxno=417190",
+                    "aid": "864951033c1bd8dd",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc222166"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "가칭 제주예술인회관, ‘지역에 꼭 필요한 예술공간’ 추진 탄력받을까?",
+                    "url": "http://www.jejusori.net/news/articleView.html?idxno=417195",
+                    "aid": "86495108b400ec38",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc222167"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "취임 1년 오영훈 제주지사-김광수 제주교육감 긍정 평가 ‘동반 하락’",
+                    "url": "http://www.jejusori.net/news/articleView.html?idxno=417180",
+                    "aid": "864950e4488c549c",
+                    "image": null,
+                    "_id": "6445133d1f0f6898fc24ddc1"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "“여름 휴가는 푸파페 제주로!” 농촌융복합 체험행사 풍성",
+                    "url": "http://www.jejusori.net/news/articleView.html?idxno=417191",
+                    "aid": "86495104ba7cdcbc",
+                    "image": null,
+                    "_id": "6445133d1f0f6898fc24ddc2"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "아픈 몸의 현상학 / 황임경",
+                    "url": "http://www.jejusori.net/news/articleView.html?idxno=417201",
+                    "aid": "864953aebeafa612",
+                    "image": null,
+                    "_id": "6445133d1f0f6898fc24ddc3"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "제주 로얄쇼핑 천장 붕괴 원인은?...‘부실공사-시설 노후화’ 의견 분분",
+                    "url": "http://www.jejusori.net/news/articleView.html?idxno=416855",
+                    "aid": "8648f6743902480c",
+                    "image": null,
+                    "_id": "6445133d1f0f6898fc24ddc4"
+                }
+            ],
+            "pid": "19",
+            "name": "KNN",
+            "logoLight": {
+                "url": "https://s.pstatic.net/static/newsstand/2020/logo/light/0604/334.png"
+            },
+            "logoDark": {
+                "url": "https://s.pstatic.net/static/newsstand/2020/logo/dark/0604/334.png"
+            },
+            "regDate": "20230717 10:33:59"
+        },
+        {
+            "materials": [
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "smartPC사랑 2023 상반기 베스트 하드웨어 어워즈 선정",
+                    "url": "https://www.ilovepc.co.kr/news/articleView.html?idxno=47208",
+                    "aid": "f1d10d514a4a5c51",
+                    "image": {
+                        "url": "https://s.pstatic.net/dthumb.phinf/?src=%22https%3A%2F%2Fs.pstatic.net%2Fstatic%2Fnewsstand%2F2023%2F0713%2Farticle_img%2Fnew_main%2F9087%2F100252_001.jpg%22&type=nf312_208&service=navermain"
+                    },
+                    "_id": "643542ba1f0f6898fc221bd1"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "가성비 게이밍 그래픽카드, 인텔 아크 A750 알아보기",
+                    "url": "https://www.ilovepc.co.kr/news/articleView.html?idxno=47112",
+                    "aid": "f1d109a9029f0be9",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc221bd2"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "2023년 7월호",
+                    "url": "http://www.ilovepc.co.kr",
+                    "aid": "167fbf961937deaa",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc221bd3"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "시원시원한 디스플레이에 휴대성까지? LG전자 2023 그램16 16ZD90RU-GX56K",
+                    "url": "https://www.ilovepc.co.kr/news/articleView.html?idxno=47218",
+                    "aid": "f1d10d70c8ab6030",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc221bd4"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "[팁] 마이크론 2400 SSD로 에이수스 로그 엘라이(ASUS ROG ALLY) 용량을 간단하게 업그레이드해보자",
+                    "url": "https://www.ilovepc.co.kr/news/articleView.html?idxno=47306",
+                    "aid": "f1d11110a25af090",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc221bd5"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "게이밍도 가능한 초경량 노트북? LG전자 2023 그램17 17Z90R-ED7VK",
+                    "url": "https://www.ilovepc.co.kr/news/articleView.html?idxno=47219",
+                    "aid": "f1d10d71166ad831",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc221bd6"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "UMPC 게임기 '옥조' 배터리 폭발 2번…휴대용 게임기 폭발 사고, 다른 제품도 있었을까?",
+                    "url": "https://www.ilovepc.co.kr/news/articleView.html?idxno=47357",
+                    "aid": "f1d111ac67ff7bec",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc221bd7"
+                }
+            ],
+            "pid": "20",
+            "name": "한국헤럴드",
+            "logoLight": {
+                "url": "https://s.pstatic.net/static/newsstand/2020/logo/light/0604/364.png"
+            },
+            "logoDark": {
+                "url": "https://s.pstatic.net/static/newsstand/2020/logo/dark/0604/364.png"
+            },
+            "regDate": "20230713 09:58:00"
+        },
+        {
+            "materials": [
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "'어둠깔린 오송 지하차도 사고현장'···도보 수색 들어간 구조대 [TF사진관]",
+                    "url": "http://news.tf.co.kr/read/photomovie/2030886.htm?from=naver",
+                    "aid": "cd08638686bd9146",
+                    "image": {
+                        "url": "https://s.pstatic.net/dthumb.phinf/?src=%22https%3A%2F%2Fs.pstatic.net%2Fstatic%2Fnewsstand%2F2023%2F0717%2Farticle_img%2Fnew_main%2F9156%2F111224_001.jpg%22&type=nf312_208&service=navermain"
+                    },
+                    "_id": "643542ba1f0f6898fc222077"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "[대전환 AI시대⑤] 보이스피싱 막는 '만능 재주꾼'…은행권에 스며든 AI",
+                    "url": "http://news.tf.co.kr/read/economy/2030646.htm",
+                    "aid": "d24e3d064c990f06",
+                    "image": null,
+                    "_id": "6490c92040d2947ae426c487"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "[韓日 연대의 섬, 소록도②] 밟힌 이의 흔적 찾기…\"응어리 풀어달라\"",
+                    "url": "http://news.tf.co.kr/read/ptoday/2030878.htm",
+                    "aid": "3b205a4c8efed334",
+                    "image": null,
+                    "_id": "6490c92040d2947ae426c488"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "미리 보는 갤럭시 언팩….갤럭시Z플립5·폴드5 스펙·가격 이렇게 나온다",
+                    "url": "http://news.tf.co.kr/read/economy/2030576.htm",
+                    "aid": "a2868ba2de5ef562",
+                    "image": null,
+                    "_id": "6490c92040d2947ae426c489"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "유기 조장 vs 영아 생존…여야, '보호출산제' 논쟁",
+                    "url": "http://news.tf.co.kr/read/ptoday/2030730.htm",
+                    "aid": "fef6008795d2f2d9",
+                    "image": null,
+                    "_id": "649edbf0530d8014e0f48a4a"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "[강일홍의 클로즈업] 최환희도 답답한 '외할머니vs여동생' 갈등",
+                    "url": "http://news.tf.co.kr/read/entertain/2030817.htm",
+                    "aid": "bd687a58260d9718",
+                    "image": null,
+                    "_id": "64b08cc0c499cc07f34a3e16"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "[단독] 'BTS 멤버인 척'…미공개 음원 유출 20대 '집행유예'",
+                    "url": "http://news.tf.co.kr/read/national/2030897.htm",
+                    "aid": "a320712a1cc61c96",
+                    "image": null,
+                    "_id": "64b08cc0c499cc07f34a3e17"
+                }
+            ],
+            "pid": "21",
+            "name": "MBC",
+            "logoLight": {
+                "url": "https://s.pstatic.net/static/newsstand/2020/logo/light/0604/536.png"
+            },
+            "logoDark": {
+                "url": "https://s.pstatic.net/static/newsstand/2020/logo/dark/0604/536.png"
+            },
+            "regDate": "20230717 11:06:35"
+        },
+        {
+            "materials": [
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "민주당 개그, 2000년 뒤까지 책임지라고 하지!",
+                    "url": "https://www.dailian.co.kr/news/view/1253750/?sc=Naver",
+                    "aid": "d6c970665deb0aa6",
+                    "image": {
+                        "url": "https://s.pstatic.net/dthumb.phinf/?src=%22https%3A%2F%2Fs.pstatic.net%2Fstatic%2Fnewsstand%2F2023%2F0717%2Farticle_img%2Fnew_main%2F9090%2F111451_001.jpg%22&type=nf312_208&service=navermain"
+                    },
+                    "_id": "643542ba1f0f6898fc221bfb"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "윤 대통령 \"비통한 마음…특별재난지역 선포 등 정책 모두 동원\"",
+                    "url": "https://www.dailian.co.kr/news/view/1253856/?sc=Naver",
+                    "aid": "42a8a76dd09ecced",
+                    "image": null,
+                    "_id": "64aa8f3b40d2947ae42c0399"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "검찰, 박영수의 \"변협회장 선거 자금 문제 될 수 있다\" 메모 확보…측근 변호사들 줄소환",
+                    "url": "https://www.dailian.co.kr/news/view/1253766/?sc=Naver",
+                    "aid": "5bd7464b94ef488b",
+                    "image": null,
+                    "_id": "64aa8f3b40d2947ae42c039a"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "탄탄한 성장 기반…수익성·여신건전성 모두 '톱' [우리금융 퀀텀점프①]",
+                    "url": "https://www.dailian.co.kr/news/view/1253208/?sc=Naver",
+                    "aid": "aee7ab0eeddff20e",
+                    "image": null,
+                    "_id": "64aa8f3b40d2947ae42c039b"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "\"韓, 4대 방산강국 도약 시 매출·고용 2배 증가…맞춤 수출전략 짜야\"",
+                    "url": "https://www.dailian.co.kr/news/view/1253657/?sc=Naver",
+                    "aid": "fa874d2ce5341a6c",
+                    "image": null,
+                    "_id": "64aa8f3b40d2947ae42c039c"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "'최대 채권자' 서울보증, 명지학원 기업회생계획 통과시켰다",
+                    "url": "https://www.dailian.co.kr/news/view/1253847/?sc=Naver",
+                    "aid": "cfdbb4cf965dc50f",
+                    "image": null,
+                    "_id": "64aa8f3b40d2947ae42c039d"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "경찰, '오송 지하차도 참사' 전담팀 구성…\"책임 소재 본격 수사\"",
+                    "url": "https://www.dailian.co.kr/news/view/1253867/?sc=Naver",
+                    "aid": "df3eff8d09f308cd",
+                    "image": null,
+                    "_id": "64aa8f3b40d2947ae42c039e"
+                }
+            ],
+            "pid": "22",
+            "name": "뉴데일리",
+            "logoLight": {
+                "url": "https://s.pstatic.net/static/newsstand/2020/logo/light/0604/368.png"
+            },
+            "logoDark": {
+                "url": "https://s.pstatic.net/static/newsstand/2020/logo/dark/0604/368.png"
+            },
+            "regDate": "20230717 11:08:52"
+        },
+        {
+            "materials": [
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "역대급 수마 덮친 전북, 2차 피해예방 '초비상'",
+                    "url": "https://www.jjan.kr/article/20230716580127",
+                    "aid": "bd22ef316cb1442f",
+                    "image": {
+                        "url": "https://s.pstatic.net/dthumb.phinf/?src=%22https%3A%2F%2Fs.pstatic.net%2Fstatic%2Fnewsstand%2F2023%2F0717%2Farticle_img%2Fnew_main%2F9066%2F094039_001.jpg%22&type=nf312_208&service=navermain"
+                    },
+                    "_id": "643542ba1f0f6898fc222181"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "'물바다' 된 전북⋯9개 시·군 424세대 753명 대피중",
+                    "url": "https://www.jjan.kr/article/20230717580002",
+                    "aid": "f209266eaeb575d2",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc222182"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "기록적 폭우 원인은? 기상학자들 \"지구 온난화\"",
+                    "url": "https://www.jjan.kr/article/20230715580035",
+                    "aid": "883cb04cadb963f4",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc222183"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "\"특별재난지역 지정을\" 유례없는 폭우에 지역구로 달려간 정치권",
+                    "url": "https://www.jjan.kr/article/20230716580333",
+                    "aid": "bd22f6ce6deffe32",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc222184"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "한국투자공사 진승호 사장, 전주 이전 거부 발언 파문",
+                    "url": "https://www.jjan.kr/article/20230716580316",
+                    "aid": "bd22f693305b974d",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc222185"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "‘구스타보 결승골’ 전북, 수원FC에 1-0 승리",
+                    "url": "https://www.jjan.kr/article/20230716580345",
+                    "aid": "bd22f6ef56ff6831",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc222186"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "발암물질 석면, 내년이면 전북 학교서 사라진다",
+                    "url": "https://www.jjan.kr/article/20230716580088",
+                    "aid": "bd22ec2bade13df5",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc222187"
+                }
+            ],
+            "pid": "23",
+            "name": "국민일보",
+            "logoLight": {
+                "url": "https://s.pstatic.net/static/newsstand/2020/logo/light/0604/336.png"
+            },
+            "logoDark": {
+                "url": "https://s.pstatic.net/static/newsstand/2020/logo/dark/0604/336.png"
+            },
+            "regDate": "20230717 09:34:24"
+        },
+        {
+            "materials": [
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "[여론조사]  인천시민 46.7% “유정복 시장 잘하고 있다”",
+                    "url": "https://www.incheonilbo.com/news/articleView.html?idxno=1203079",
+                    "aid": "284d86dd9e09acdd",
+                    "image": {
+                        "url": "https://s.pstatic.net/dthumb.phinf/?src=%22https%3A%2F%2Fs.pstatic.net%2Fstatic%2Fnewsstand%2F2023%2F0717%2Farticle_img%2Fnew_main%2F9097%2F112248_001.jpg%22&type=nf312_208&service=navermain"
+                    },
+                    "_id": "643542ba1f0f6898fc221d9f"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "[여론조사] 김동연 경기지사 지지율 급상승…“잘한다” 57.1%",
+                    "url": "https://www.incheonilbo.com/news/articleView.html?idxno=1203082",
+                    "aid": "284d86f5a13cbcb5",
+                    "image": null,
+                    "_id": "64aa5830d509cf07e8701c29"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "[여론조사] 인천시민·경기도민 윤석열 대통령 국정수행 평가",
+                    "url": "https://www.incheonilbo.com/news/articleView.html?idxno=1203075",
+                    "aid": "284d86d9d8c36ed9",
+                    "image": null,
+                    "_id": "64ab9b5df04b5ed2c5434f2b"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "[여론조사] 경기도민·인천시민 정당 지지도…민주당·국민의힘, 오차범위 내 '엎치락뒤치락'",
+                    "url": "https://www.incheonilbo.com/news/articleView.html?idxno=1203074",
+                    "aid": "284d86d8e771df58",
+                    "image": null,
+                    "_id": "64ab9b5df04b5ed2c5434f2c"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "[여론조사] 내년 총선, 인천시민은 변화 바란다",
+                    "url": "https://www.incheonilbo.com/news/articleView.html?idxno=1203077",
+                    "aid": "284d86dbbb668ddb",
+                    "image": null,
+                    "_id": "64ab9b5df04b5ed2c5434f2d"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "[여론조사] 내년 총선, 경기도민은 변화 바란다…지역 국회의원 '물갈이' 원해",
+                    "url": "https://www.incheonilbo.com/news/articleView.html?idxno=1203078",
+                    "aid": "284d86dcacb81d5c",
+                    "image": null,
+                    "_id": "64b3d1f51f0f6898fc3a224d"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "[창간 35주년 여론조사] 김동연 경기지사 지지율 급상승 이유…철도망 확충·민생경제 주 요인",
+                    "url": "https://www.incheonilbo.com/news/articleView.html?idxno=1203092",
+                    "aid": "284d87143daab914",
+                    "image": null,
+                    "_id": "64b3d1f51f0f6898fc3a224e"
+                }
+            ],
+            "pid": "24",
+            "name": "일간스포츠",
+            "logoLight": {
+                "url": "https://s.pstatic.net/static/newsstand/up/2022/0331/nsd155937506.png"
+            },
+            "logoDark": {
+                "url": "https://s.pstatic.net/static/newsstand/up/2022/0331/nsd15594915.png"
+            },
+            "regDate": "20230717 11:20:04"
+        },
+        {
+            "materials": [
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "'CJ 승계 핵심'은 올리브영?… 이재현의 큰 그림",
+                    "url": "https://www.moneys.co.kr/news/mwView.php?no=2023071414520662204&type=4&code=w0405&STAND=ST",
+                    "aid": "4274ad77e350c369",
+                    "image": {
+                        "url": "https://s.pstatic.net/dthumb.phinf/?src=%22https%3A%2F%2Fs.pstatic.net%2Fstatic%2Fnewsstand%2F2023%2F0717%2Farticle_img%2Fnew_main%2F9159%2F111224_001.jpg%22&type=nf312_208&service=navermain"
+                    },
+                    "_id": "643542ba1f0f6898fc222085"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "\"대출금리 올라\" 영끌족 비명… 주담대 금리 7% 육박",
+                    "url": "https://www.moneys.co.kr/news/mwView.php?no=2023071709462957121&type=4&code=w0202&STAND=SS",
+                    "aid": "2cf2ad96429f8f6a",
+                    "image": null,
+                    "_id": "64a0948c3e93486eac6c1932"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "'납품가 기싸움' 쿠팡, '햇반' 없어도 괜찮다?",
+                    "url": "https://www.moneys.co.kr/news/mwView.php?no=2023071708431989095&type=4&code=w0405&STAND=SS",
+                    "aid": "3a09765135e320cf",
+                    "image": null,
+                    "_id": "64aee3d4e82d6f14f22a6395"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "국제선 결항 아시아나, 비상대책 가동… 승객 피해 최소화",
+                    "url": "https://www.moneys.co.kr/news/mwView.php?no=2023071710195737812&type=4&code=w0406&STAND=SS",
+                    "aid": "0d3da8e06e1e4da0",
+                    "image": null,
+                    "_id": "64aee3d4e82d6f14f22a6396"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "韓 폭우 피해, 외신도 관심… \"동아시아 기후 위기 직면\"",
+                    "url": "https://www.moneys.co.kr/news/mwView.php?no=2023071709153565027&type=4&code=w1604&STAND=SS",
+                    "aid": "a791c706c35332fa",
+                    "image": null,
+                    "_id": "64b17417e9bedeca622c07f6"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "오송 지하차도 참사 현장서 웃은 공무원… \"소름 끼친다\"",
+                    "url": "https://www.moneys.co.kr/news/mwView.php?no=2023071709575642600&type=4&code=w1602&STAND=SS",
+                    "aid": "225ebaa3d87cf6fd",
+                    "image": null,
+                    "_id": "64b17417e9bedeca622c07f7"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "\"역시 불사조\"… 주윤발 건강이상설, '가짜뉴스'로 판명",
+                    "url": "https://www.moneys.co.kr/news/mwView.php?no=2023071708503414165&type=4&code=w1604&STAND=SS",
+                    "aid": "eb438184bf7625bc",
+                    "image": null,
+                    "_id": "64b17417e9bedeca622c07f8"
+                }
+            ],
+            "pid": "25",
+            "name": "ZDNET Korea",
+            "logoLight": {
+                "url": "https://s.pstatic.net/static/newsstand/2020/logo/light/0604/417.png"
+            },
+            "logoDark": {
+                "url": "https://s.pstatic.net/static/newsstand/2020/logo/dark/0604/417.png"
+            },
+            "regDate": "20230717 11:10:05"
+        }
+    ],
+    "3": [
+        {
+            "materials": [
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "[겜ㅊㅊ] 엑조프라이멀 못지 않은, 공룡 때려잡는 게임 5선",
+                    "url": "https://www.gamemeca.com/view.php?gid=1739246",
+                    "aid": "fd77bcda2444469a",
+                    "image": {
+                        "url": "https://s.pstatic.net/dthumb.phinf/?src=%22https%3A%2F%2Fs.pstatic.net%2Fstatic%2Fnewsstand%2F2023%2F0717%2Farticle_img%2Fnew_main%2F9082%2F110339_001.jpg%22&type=nf312_208&service=navermain"
+                    },
+                    "_id": "643542ba1f0f6898fc221b61"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "[롤짤] 전자두뇌 피넛",
+                    "url": "https://www.gamemeca.com/view.php?gid=1739241",
+                    "aid": "fd77bcd5d28cb1d5",
+                    "image": null,
+                    "_id": "648bf6ed6e592107d2de4286"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "[판례.zip] 게임사 상대 소송에서 유저 승소가 늘고 있다",
+                    "url": "https://www.gamemeca.com/view.php?gid=1739182",
+                    "aid": "fd77b991dd34ce11",
+                    "image": null,
+                    "_id": "648bf6ed6e592107d2de4287"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "새 마스코트 등장? 반반의 유치원 4 트레일러 공개",
+                    "url": "https://www.gamemeca.com/view.php?gid=1739229",
+                    "aid": "fd77bc9f0b92539f",
+                    "image": null,
+                    "_id": "648bf6ed6e592107d2de4288"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "금강선 디렉터, 향후 업데이트는 엔드 콘텐츠 최우선으로",
+                    "url": "https://www.gamemeca.com/view.php?gid=1739227",
+                    "aid": "fd77bc9d847c181d",
+                    "image": null,
+                    "_id": "648bf6ed6e592107d2de4289"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "원신 영문 성우 임금체불, 호요버스 \"녹음 스튜디오가 미지불\"",
+                    "url": "https://www.gamemeca.com/view.php?gid=1739221",
+                    "aid": "fd77bc97ef396597",
+                    "image": null,
+                    "_id": "648bf6ed6e592107d2de428a"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "수동조작 하고 싶어지는 SF MMORPG, 아레스",
+                    "url": "https://www.gamemeca.com/view.php?gid=1739066",
+                    "aid": "fd77b59608845ed6",
+                    "image": null,
+                    "_id": "648bf6ed6e592107d2de428b"
+                }
+            ],
+            "pid": "26",
+            "name": "마이데일리",
+            "logoLight": {
+                "url": "https://s.pstatic.net/static/newsstand/2020/logo/light/0604/356.png"
+            },
+            "logoDark": {
+                "url": "https://s.pstatic.net/static/newsstand/2020/logo/dark/0604/356.png"
+            },
+            "regDate": "20230717 10:59:06"
+        },
+        {
+            "materials": [
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "제주도, 노후 차집관로 2026년까지 전면 교체",
+                    "url": "http://www.jejudomin.co.kr/news/articleView.html?idxno=218066",
+                    "aid": "16dfd360b7561820",
+                    "image": {
+                        "url": "https://s.pstatic.net/dthumb.phinf/?src=%22https%3A%2F%2Fs.pstatic.net%2Fstatic%2Fnewsstand%2F2023%2F0717%2Farticle_img%2Fnew_main%2F9099%2F111451_001.jpg%22&type=nf312_208&service=navermain"
+                    },
+                    "_id": "643542ba1f0f6898fc221db4"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "제주도의회, 강경흠 의원 징계 착수…사퇴 요구 잇따라",
+                    "url": "http://www.jejudomin.co.kr/news/articleView.html?idxno=218046",
+                    "aid": "16dfd322e2f707e2",
+                    "image": null,
+                    "_id": "64af13a4548a597b72d3604a"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "제주도 ‘공공주도 2.0 풍력 조례’ 의회서 ‘제동’",
+                    "url": "http://www.jejudomin.co.kr/news/articleView.html?idxno=218022",
+                    "aid": "16dfd2e09f9208a0",
+                    "image": null,
+                    "_id": "64af13a4548a597b72d3604b"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "제주 자원순환사회 조성 핵심기반시설 본격 가동",
+                    "url": "http://www.jejudomin.co.kr/news/articleView.html?idxno=218057",
+                    "aid": "16dfd34228e80bc2",
+                    "image": null,
+                    "_id": "64b02a1363b70c6ebed54bff"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "양파·당근 과잉생산 우려...10% 이상 감축 필요",
+                    "url": "http://www.jejudomin.co.kr/news/articleView.html?idxno=218055",
+                    "aid": "16dfd34071651440",
+                    "image": null,
+                    "_id": "64b14b113c50cd9912fcde86"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "제주, 동물등록 8.7% 늘고↑...유기동물 11.8% 감소↓",
+                    "url": "http://www.jejudomin.co.kr/news/articleView.html?idxno=218054",
+                    "aid": "16dfd33f95a3987f",
+                    "image": null,
+                    "_id": "64b14b113c50cd9912fcde87"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "제주 마을관광 브랜드 ‘카름스테이’ 3곳 신규 선정",
+                    "url": "http://www.jejudomin.co.kr/news/articleView.html?idxno=218045",
+                    "aid": "16dfd32107358c21",
+                    "image": null,
+                    "_id": "64b284a8e82d6f14f22b4cc4"
+                }
+            ],
+            "pid": "27",
+            "name": "SBS",
+            "logoLight": {
+                "url": "https://s.pstatic.net/static/newsstand/2020/logo/light/0604/389.png"
+            },
+            "logoDark": {
+                "url": "https://s.pstatic.net/static/newsstand/2020/logo/dark/0604/389.png"
+            },
+            "regDate": "20230717 11:10:38"
+        },
+        {
+            "materials": [
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "충북 오송 지하차도서 밤사이 추가 수습…13명 사망",
+                    "url": "https://www.yonhapnewstv.co.kr/news/MYH20230717002000641",
+                    "aid": "2ca7da7022378990",
+                    "image": {
+                        "url": "https://s.pstatic.net/dthumb.phinf/?src=%22https%3A%2F%2Fs.pstatic.net%2Fstatic%2Fnewsstand%2F2023%2F0717%2Farticle_img%2Fnew_main%2F9109%2F112248_001.jpg%22&type=nf312_208&service=navermain"
+                    },
+                    "_id": "643542ba1f0f6898fc2220a1"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "충청이남 1년 강수량 60% 집중…주초에도 물벼락",
+                    "url": "https://www.yonhapnewstv.co.kr/news/MYH20230716016400641",
+                    "aid": "7aabe5b0597a9cd0",
+                    "image": null,
+                    "_id": "64a8715ec499cc07f3489dfc"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "위험 감수한 왕복 27시간…\"가치외교 실천\"",
+                    "url": "https://www.yonhapnewstv.co.kr/news/MYH20230716016100641",
+                    "aid": "758d5bd3e8be81cd",
+                    "image": null,
+                    "_id": "64a8715ec499cc07f3489dfd"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "여야, 수해 현장 방문…\"재난지역 선포\" 한목소리",
+                    "url": "https://www.yonhapnewstv.co.kr/news/MYH20230716015900641",
+                    "aid": "4e4de58a142876f6",
+                    "image": null,
+                    "_id": "64a8715ec499cc07f3489dfe"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "한미일, 동해상 미사일 방어훈련…북 ICBM 대응",
+                    "url": "https://www.yonhapnewstv.co.kr/news/MYH20230716017100641",
+                    "aid": "aa739714e9f4d4ac",
+                    "image": null,
+                    "_id": "64ac235223adad7ad2994cdd"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "[기업기상도] 기회 맞아 맑은 기업 vs 극한호우에 젖은 기업",
+                    "url": "https://www.yonhapnewstv.co.kr/news/MYH20230715009400641",
+                    "aid": "bd33f975a68e8eab",
+                    "image": null,
+                    "_id": "64ac235223adad7ad2994cde"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "할리우드가 뿔났다…63년만에 작가·배우조합 동반파업",
+                    "url": "https://www.yonhapnewstv.co.kr/news/MYH20230716006700641",
+                    "aid": "17e942aea0e26292",
+                    "image": null,
+                    "_id": "64ac235223adad7ad2994cdf"
+                }
+            ],
+            "pid": "28",
+            "name": "서울경제",
+            "logoLight": {
+                "url": "https://s.pstatic.net/static/newsstand/2020/logo/light/0604/422.png"
+            },
+            "logoDark": {
+                "url": "https://s.pstatic.net/static/newsstand/2020/logo/dark/0604/422.png"
+            },
+            "regDate": "20230717 11:22:16"
+        },
+        {
+            "materials": [
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "엔하이픈·보이넥스트도어·카드·폴킴·김재환·이승윤, ‘2023 K 글로벌 하트 드림 어워즈’ 뜬다",
+                    "url": "http://www.tvdaily.co.kr/read.php3?aid=16895507701679687010",
+                    "aid": "8ea56e7a08f7653a",
+                    "image": {
+                        "url": "https://s.pstatic.net/dthumb.phinf/?src=%22https%3A%2F%2Fs.pstatic.net%2Fstatic%2Fnewsstand%2F2023%2F0717%2Farticle_img%2Fnew_main%2F9119%2F112248_001.jpg%22&type=nf312_208&service=navermain"
+                    },
+                    "_id": "643542ba1f0f6898fc2220d2"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "故 최진실 아들 최환희, 동생 최준희 논란에 대신 고개 숙였다 [이슈&톡]",
+                    "url": "http://www.tvdaily.co.kr/read.php3?aid=16894584001679674002",
+                    "aid": "ba8dcfbccd8f03fc",
+                    "image": null,
+                    "_id": "64b0d968052e097ad990e7ab"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "'미임파7' 개봉 첫 주말 120만 명 동원, 압도적 1위 [박스오피스]",
+                    "url": "http://www.tvdaily.co.kr/read.php3?aid=16895545961679692008",
+                    "aid": "c5e1d4c796ed9707",
+                    "image": null,
+                    "_id": "64b0d968052e097ad990e7ac"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "김우빈·이찬원, 수해 이재민 위해 1억원 기부",
+                    "url": "http://www.tvdaily.co.kr/read.php3?aid=16895449511679679002",
+                    "aid": "1ebb70da178696da",
+                    "image": null,
+                    "_id": "64b0d968052e097ad990e7ad"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "남규리, 하이어랭크 엔터테인먼트 전속계약",
+                    "url": "http://www.tvdaily.co.kr/read.php3?aid=16895575591679699002",
+                    "aid": "0b65e2fe6f3ea8be",
+                    "image": null,
+                    "_id": "64b0d968052e097ad990e7ae"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "[TD포토] 블랙핑크 로제 '예쁨이 한가득~'",
+                    "url": "http://www.tvdaily.co.kr/read.php3?aid=16893023711679539017",
+                    "aid": "a6d26613c2708193",
+                    "image": null,
+                    "_id": "64b0d968052e097ad990e7af"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "[TD영상] 정일우-박은석, 김병만 '꿈 꾸는 아이'같은 모습에 놀라",
+                    "url": "http://www.tvdaily.co.kr/read.php3?aid=16893209111679623003",
+                    "aid": "0159f4e4bd4962e4",
+                    "image": null,
+                    "_id": "64b0d968052e097ad990e7b0"
+                }
+            ],
+            "pid": "29",
+            "name": "매일경제",
+            "logoLight": {
+                "url": "https://s.pstatic.net/static/newsstand/2020/logo/light/0604/440.png"
+            },
+            "logoDark": {
+                "url": "https://s.pstatic.net/static/newsstand/2020/logo/dark/0604/440.png"
+            },
+            "regDate": "20230717 11:20:02"
+        },
+        {
+            "materials": [
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "엄정화·김완선·이효리…화사는 '언니'들이 지킨다",
+                    "url": "http://www.sportsworldi.com/newsView/20230717506063",
+                    "aid": "4fe028c2cf60f142",
+                    "image": {
+                        "url": "https://s.pstatic.net/dthumb.phinf/?src=%22https%3A%2F%2Fs.pstatic.net%2Fstatic%2Fnewsstand%2F2023%2F0717%2Farticle_img%2Fnew_main%2F9120%2F112108_001.jpg%22&type=nf312_208&service=navermain"
+                    },
+                    "_id": "643542ba1f0f6898fc221e6a"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "노경은·노진혁이 첫 올스타전을 즐기는 법",
+                    "url": "http://www.sportsworldi.com/newsView/20230715513661",
+                    "aid": "e62083283404d8e8",
+                    "image": null,
+                    "_id": "649673e740d2947ae427e960"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "넷플 '트렁크', 서현진·공유 캐스팅 확정",
+                    "url": "http://www.sportsworldi.com/newsView/20230717506152",
+                    "aid": "4fe02c63d1eaeaa3",
+                    "image": null,
+                    "_id": "649673e740d2947ae427e961"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "'킹더랜드' 이준호♥임윤아, 달빛 입맞춤",
+                    "url": "http://www.sportsworldi.com/newsView/20230717505503",
+                    "aid": "4fdfc66e7ca52bae",
+                    "image": null,
+                    "_id": "649673e740d2947ae427e962"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "'통영 배수저' 송지효, 난생 첫 인턴 경험",
+                    "url": "http://www.sportsworldi.com/newsView/20230717508633",
+                    "aid": "4fe127a9f7eef569",
+                    "image": null,
+                    "_id": "649673e740d2947ae427e963"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "'미션 임파서블7' 개봉 첫 주 176만…압도적 1위",
+                    "url": "http://www.sportsworldi.com/newsView/20230717509028",
+                    "aid": "4fe18568d4be4ea8",
+                    "image": null,
+                    "_id": "649673e740d2947ae427e964"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "주우재, 모델 시절 '전 여친' 한 마디에…",
+                    "url": "http://www.sportsworldi.com/newsView/20230717506532",
+                    "aid": "4fe03b2974cf99e9",
+                    "image": null,
+                    "_id": "649673e740d2947ae427e965"
+                }
+            ],
+            "pid": "30",
+            "name": "MBN",
+            "logoLight": {
+                "url": "https://s.pstatic.net/static/newsstand/2020/logo/light/0604/396.png"
+            },
+            "logoDark": {
+                "url": "https://s.pstatic.net/static/newsstand/2020/logo/dark/0604/396.png"
+            },
+            "regDate": "20230717 11:20:31"
+        },
+        {
+            "materials": [
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "[단독] 국교위, 전교조 추천 국교위원 '거부'…...",
+                    "url": "https://home.ebs.co.kr/ebsnews/menu1/newsAllView/60371726/N?eduNewsYn=N",
+                    "aid": "63b436be78a97cbe",
+                    "image": {
+                        "url": "https://s.pstatic.net/dthumb.phinf/?src=%22https%3A%2F%2Fs.pstatic.net%2Fstatic%2Fnewsstand%2F2023%2F0717%2Farticle_img%2Fnew_main%2F9076%2F104306_001.png%22&type=nf312_208&service=navermain"
+                    },
+                    "_id": "643542ba1f0f6898fc2221a4"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "영아 유기·살해 확인 계속…후속 입법 속도",
+                    "url": "https://home.ebs.co.kr/ebsnews/menu1/newsAllView/60371727/N?eduNewsYn=N",
+                    "aid": "bd8fa0ff6c3900ff",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc2221a5"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "<뉴스브릿지> 계약 종료 후 '이름' 잃는 가수들…분쟁 원인과 해결책은",
+                    "url": "https://home.ebs.co.kr/ebsnews/menu1/newsAllView/60371728/N?eduNewsYn=N",
+                    "aid": "176b0b405fc88540",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc2221a6"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "[단독] 반수생 급증 현실화되나…9월 모평 학원 응시생 전년比 1,536명↑",
+                    "url": "https://home.ebs.co.kr/ebsnews/menu1/newsAllView/60371690/N?eduNewsYn=N",
+                    "aid": "22e2ec50168bd010",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc2221a7"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "어린이집‧유치원 대기 인원 한눈에…통합정보 개편",
+                    "url": "https://home.ebs.co.kr/ebsnews/menu1/newsAllView/60371691/N?eduNewsYn=N",
+                    "aid": "7cbe56910a1b5451",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc2221a8"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "영아살해 '솜방망이' 개선…70년만 형법 개정 추진",
+                    "url": "https://home.ebs.co.kr/ebsnews/menu1/newsAllView/60371692/N?eduNewsYn=N",
+                    "aid": "d699c0d2fdaad892",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc2221a9"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "'4세대 나이스' 불편 이어져…안정화 과제는?",
+                    "url": "https://home.ebs.co.kr/ebsnews/menu1/newsAllView/60371410/N?eduNewsYn=N",
+                    "aid": "75004156ad1216",
+                    "image": null,
+                    "_id": "64a69d1558a9ce6eb3c6d2e8"
+                }
+            ],
+            "pid": "31",
+            "name": "YTN",
+            "logoLight": {
+                "url": "https://s.pstatic.net/static/newsstand/up/2020/0803/nsd20247547.png"
+            },
+            "logoDark": {
+                "url": "https://s.pstatic.net/static/newsstand/up/2020/0803/nsd202358800.png"
+            },
+            "regDate": "20230717 10:35:16"
+        },
+        {
+            "materials": [
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "[겜ㅊㅊ] 엑조프라이멀 못지 않은, 공룡 때려잡는 게임 5선",
+                    "url": "https://www.gamemeca.com/view.php?gid=1739246",
+                    "aid": "fd77bcda2444469a",
+                    "image": {
+                        "url": "https://s.pstatic.net/dthumb.phinf/?src=%22https%3A%2F%2Fs.pstatic.net%2Fstatic%2Fnewsstand%2F2023%2F0717%2Farticle_img%2Fnew_main%2F9082%2F110339_001.jpg%22&type=nf312_208&service=navermain"
+                    },
+                    "_id": "643542ba1f0f6898fc221b61"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "[롤짤] 전자두뇌 피넛",
+                    "url": "https://www.gamemeca.com/view.php?gid=1739241",
+                    "aid": "fd77bcd5d28cb1d5",
+                    "image": null,
+                    "_id": "648bf6ed6e592107d2de4286"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "[판례.zip] 게임사 상대 소송에서 유저 승소가 늘고 있다",
+                    "url": "https://www.gamemeca.com/view.php?gid=1739182",
+                    "aid": "fd77b991dd34ce11",
+                    "image": null,
+                    "_id": "648bf6ed6e592107d2de4287"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "새 마스코트 등장? 반반의 유치원 4 트레일러 공개",
+                    "url": "https://www.gamemeca.com/view.php?gid=1739229",
+                    "aid": "fd77bc9f0b92539f",
+                    "image": null,
+                    "_id": "648bf6ed6e592107d2de4288"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "금강선 디렉터, 향후 업데이트는 엔드 콘텐츠 최우선으로",
+                    "url": "https://www.gamemeca.com/view.php?gid=1739227",
+                    "aid": "fd77bc9d847c181d",
+                    "image": null,
+                    "_id": "648bf6ed6e592107d2de4289"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "원신 영문 성우 임금체불, 호요버스 \"녹음 스튜디오가 미지불\"",
+                    "url": "https://www.gamemeca.com/view.php?gid=1739221",
+                    "aid": "fd77bc97ef396597",
+                    "image": null,
+                    "_id": "648bf6ed6e592107d2de428a"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "수동조작 하고 싶어지는 SF MMORPG, 아레스",
+                    "url": "https://www.gamemeca.com/view.php?gid=1739066",
+                    "aid": "fd77b59608845ed6",
+                    "image": null,
+                    "_id": "648bf6ed6e592107d2de428b"
+                }
+            ],
+            "pid": "32",
+            "name": "시사위크",
+            "logoLight": {
+                "url": "https://s.pstatic.net/static/newsstand/2020/logo/light/0604/356.png"
+            },
+            "logoDark": {
+                "url": "https://s.pstatic.net/static/newsstand/2020/logo/dark/0604/356.png"
+            },
+            "regDate": "20230717 10:59:06"
+        },
+        {
+            "materials": [
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "수출·내수·고용 개선, 경기 둔화 끝 보인다",
+                    "url": "https://www.joongang.co.kr/article/25177503?utm_source=navernewsstand&utm_medium=referral&utm_campaign=left1image1_newsstand&utm_content=230715",
+                    "aid": "14bb6c68679e5d28",
+                    "image": {
+                        "url": "https://s.pstatic.net/dthumb.phinf/?src=%22https%3A%2F%2Fs.pstatic.net%2Fstatic%2Fnewsstand%2F2023%2F0715%2Farticle_img%2Fnew_main%2F9227%2F065457_001.jpg%22&type=nf312_208&service=navermain"
+                    },
+                    "_id": "643542ba1f0f6898fc221b4c"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "오염수 '가짜 과학'이 국민 혼 빼앗아 괴담으로 번져",
+                    "url": "https://www.joongang.co.kr/article/25177453?utm_source=navernewsstand&utm_medium=referral&utm_campaign=left2image1_newsstand&utm_content=230715",
+                    "aid": "2f6aeca1cec28e61",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc221b4d"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "세계 당구 고수들 K구장의 결투…'롱롱남매' 최다승",
+                    "url": "https://www.joongang.co.kr/article/25177456?utm_source=navernewsstand&utm_medium=referral&utm_campaign=left2image2_newsstand&utm_content=230715",
+                    "aid": "3b397ac32ccf3743",
+                    "image": null,
+                    "_id": "643de4cc58a9ce6eb3b2bb20"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "미 긴축·불황에도 일자리 늘어…고용지표 역주행 이유",
+                    "url": "https://www.joongang.co.kr/article/25177497?utm_source=navernewsstand&utm_medium=referral&utm_campaign=left2image3_newsstand&utm_content=230715",
+                    "aid": "b66a045f72f3339f",
+                    "image": null,
+                    "_id": "644220ca548a597b72bed489"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "폭포비 피해 속출…2명 사망·1명 실종",
+                    "url": "https://www.joongang.co.kr/article/25177494?utm_source=navernewsstand&utm_medium=referral&utm_campaign=left3article1_newsstand&utm_content=230715",
+                    "aid": "64706958e11ffa18",
+                    "image": null,
+                    "_id": "644220ca548a597b72bed48a"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "다음주 '명낙 회동' 손 맞잡을까, 헤어질 결심할까 촉각",
+                    "url": "https://www.joongang.co.kr/article/25177454?utm_source=navernewsstand&utm_medium=referral&utm_campaign=left3article2_newsstand&utm_content=230715",
+                    "aid": "bf7f317b3cda11bb",
+                    "image": null,
+                    "_id": "644220ca548a597b72bed48b"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "AI로 감쪽같이 합성…실제와 똑같은 가짜에 눈 뜨고도 당한다",
+                    "url": "https://www.joongang.co.kr/article/25177455?utm_source=navernewsstand&utm_medium=referral&utm_campaign=left3article3_newsstand&utm_content=230715",
+                    "aid": "03924c5b7f484adb",
+                    "image": null,
+                    "_id": "644220ca548a597b72bed48c"
+                }
+            ],
+            "pid": "33",
+            "name": "세계일보",
+            "logoLight": {
+                "url": "https://s.pstatic.net/static/newsstand/2020/logo/light/0604/353.png"
+            },
+            "logoDark": {
+                "url": "https://s.pstatic.net/static/newsstand/2020/logo/dark/0604/353.png"
+            },
+            "regDate": "20230715 06:51:19"
+        },
+        {
+            "materials": [
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "Death toll from rains at 40 with 13 killed in flooded tunnel",
+                    "url": "https://koreajoongangdaily.joins.com/2023/07/17/national/socialAffairs/osong-underpass-heavy-rain/20230717093506335.html",
+                    "aid": "effadea33b4a4f3d",
+                    "image": {
+                        "url": "https://s.pstatic.net/dthumb.phinf/?src=%22https%3A%2F%2Fs.pstatic.net%2Fstatic%2Fnewsstand%2F2023%2F0717%2Farticle_img%2Fnew_main%2F9061%2F105218_001.jpg%22&type=nf312_208&service=navermain"
+                    },
+                    "_id": "643542ba1f0f6898fc222142"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "Yoon orders all-out support to heavy rains",
+                    "url": "https://koreajoongangdaily.joins.com/2023/07/17/national/politics/Korea-Yoon-Suk-Yeol-rain/20230717102737010.html",
+                    "aid": "f0bfa83495337cf4",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc222143"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "Hyundai Motor begins comeback in China",
+                    "url": "https://koreajoongangdaily.joins.com/2023/07/15/business/industry/korea-china-ioniq-n/20230715070013188.html",
+                    "aid": "057a6fdfb5cfff01",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc222144"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "Over 45 people dead, missing across Korea as monsoon season rages",
+                    "url": "https://koreajoongangdaily.joins.com/2023/07/16/national/socialAffairs/korea-monsoon-rain/20230716185100715.html",
+                    "aid": "36049e19ef4d3a07",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc222145"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "Flood waters devastate residents in North Chungcheong",
+                    "url": "https://koreajoongangdaily.joins.com/2023/07/16/national/socialAffairs/Osong-underpass-torrential-rain/20230716165509045.html",
+                    "aid": "2306d145b483c105",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc222146"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "Yoon pledges security, humanitarian and reconstruction aid to Ukraine",
+                    "url": "https://koreajoongangdaily.joins.com/2023/07/16/national/diplomacy/Korea-Ukraine-bilateral-summit/20230716152427658.html",
+                    "aid": "2657b1bcd528d8c4",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc222147"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "[THINK ENGLISH] SSG 랜더스 2군 선수들, 폭행 사건 연루",
+                    "url": "https://koreajoongangdaily.joins.com/2023/07/17/sports/Baseball/THINK-ENGLISH-SSG-Landers-physical-abuse/20230717093326353.html",
+                    "aid": "31b05a78de3c2e38",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc222148"
+                }
+            ],
+            "pid": "34",
+            "name": "디지털투데이",
+            "logoLight": {
+                "url": "https://s.pstatic.net/static/newsstand/2020/logo/light/0604/330.png"
+            },
+            "logoDark": {
+                "url": "https://s.pstatic.net/static/newsstand/2020/logo/dark/0604/330.png"
+            },
+            "regDate": "20230717 10:43:52"
+        },
+        {
+            "materials": [
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "수출·내수·고용 개선, 경기 둔화 끝 보인다",
+                    "url": "https://www.joongang.co.kr/article/25177503?utm_source=navernewsstand&utm_medium=referral&utm_campaign=left1image1_newsstand&utm_content=230715",
+                    "aid": "14bb6c68679e5d28",
+                    "image": {
+                        "url": "https://s.pstatic.net/dthumb.phinf/?src=%22https%3A%2F%2Fs.pstatic.net%2Fstatic%2Fnewsstand%2F2023%2F0715%2Farticle_img%2Fnew_main%2F9227%2F065457_001.jpg%22&type=nf312_208&service=navermain"
+                    },
+                    "_id": "643542ba1f0f6898fc221b4c"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "오염수 '가짜 과학'이 국민 혼 빼앗아 괴담으로 번져",
+                    "url": "https://www.joongang.co.kr/article/25177453?utm_source=navernewsstand&utm_medium=referral&utm_campaign=left2image1_newsstand&utm_content=230715",
+                    "aid": "2f6aeca1cec28e61",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc221b4d"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "세계 당구 고수들 K구장의 결투…'롱롱남매' 최다승",
+                    "url": "https://www.joongang.co.kr/article/25177456?utm_source=navernewsstand&utm_medium=referral&utm_campaign=left2image2_newsstand&utm_content=230715",
+                    "aid": "3b397ac32ccf3743",
+                    "image": null,
+                    "_id": "643de4cc58a9ce6eb3b2bb20"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "미 긴축·불황에도 일자리 늘어…고용지표 역주행 이유",
+                    "url": "https://www.joongang.co.kr/article/25177497?utm_source=navernewsstand&utm_medium=referral&utm_campaign=left2image3_newsstand&utm_content=230715",
+                    "aid": "b66a045f72f3339f",
+                    "image": null,
+                    "_id": "644220ca548a597b72bed489"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "폭포비 피해 속출…2명 사망·1명 실종",
+                    "url": "https://www.joongang.co.kr/article/25177494?utm_source=navernewsstand&utm_medium=referral&utm_campaign=left3article1_newsstand&utm_content=230715",
+                    "aid": "64706958e11ffa18",
+                    "image": null,
+                    "_id": "644220ca548a597b72bed48a"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "다음주 '명낙 회동' 손 맞잡을까, 헤어질 결심할까 촉각",
+                    "url": "https://www.joongang.co.kr/article/25177454?utm_source=navernewsstand&utm_medium=referral&utm_campaign=left3article2_newsstand&utm_content=230715",
+                    "aid": "bf7f317b3cda11bb",
+                    "image": null,
+                    "_id": "644220ca548a597b72bed48b"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "AI로 감쪽같이 합성…실제와 똑같은 가짜에 눈 뜨고도 당한다",
+                    "url": "https://www.joongang.co.kr/article/25177455?utm_source=navernewsstand&utm_medium=referral&utm_campaign=left3article3_newsstand&utm_content=230715",
+                    "aid": "03924c5b7f484adb",
+                    "image": null,
+                    "_id": "644220ca548a597b72bed48c"
+                }
+            ],
+            "pid": "35",
+            "name": "데이터뉴스",
+            "logoLight": {
+                "url": "https://s.pstatic.net/static/newsstand/2020/logo/light/0604/353.png"
+            },
+            "logoDark": {
+                "url": "https://s.pstatic.net/static/newsstand/2020/logo/dark/0604/353.png"
+            },
+            "regDate": "20230715 06:51:19"
+        }
+    ],
+    "4": [
+        {
+            "materials": [
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "최대 200㎜ 물폭탄… 침수·산사태 위험지 수백명 긴급 대피",
+                    "url": "http://www.knnews.co.kr/news/articleView.php?idxno=1409013",
+                    "aid": "bf2851f8824cf908",
+                    "image": {
+                        "url": "https://s.pstatic.net/dthumb.phinf/?src=%22https%3A%2F%2Fs.pstatic.net%2Fstatic%2Fnewsstand%2F2023%2F0717%2Farticle_img%2Fnew_main%2F9072%2F110825_001.jpg%22&type=nf312_208&service=navermain"
+                    },
+                    "_id": "643542ba1f0f6898fc222157"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "도내 침수 취약주택 30% “비용 부담돼 물막이판 설치 안 해”",
+                    "url": "http://www.knnews.co.kr/news/articleView.php?idxno=1409021",
+                    "aid": "bf285215791a758b",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc222158"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "창녕함안보 등 4대강 보 정책 ‘해체’서 ‘존치’로 바뀔 듯",
+                    "url": "http://www.knnews.co.kr/news/articleView.php?idxno=1409016",
+                    "aid": "bf2851fbfd7004a5",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc222159"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "지리산 인근 지자체 ‘케이블카 재추진’ 시끌",
+                    "url": "http://www.knnews.co.kr/news/articleView.php?idxno=1409000",
+                    "aid": "bf2851d6139a692a",
+                    "image": null,
+                    "_id": "64713b656e592107d2d9ae55"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "오염수 우려에 손님 줄었는데 장마까지… 어시장 상인 시름",
+                    "url": "http://www.knnews.co.kr/news/articleView.php?idxno=1409011",
+                    "aid": "bf2851f6858af14a",
+                    "image": null,
+                    "_id": "64997f72530d8014e0f35b08"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "보건의료노조 총파업 종료… 양산부산대병원은 파업 계속",
+                    "url": "http://www.knnews.co.kr/news/articleView.php?idxno=1409018",
+                    "aid": "bf2851fdfa320c63",
+                    "image": null,
+                    "_id": "64997f72530d8014e0f35b09"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "경남도의회 “경남TP 원장 후보 ‘유흥접대 전력’ 있을 수 있는 일”",
+                    "url": "http://www.knnews.co.kr/news/articleView.php?idxno=1409022",
+                    "aid": "bf285216f77b796a",
+                    "image": null,
+                    "_id": "64997f72530d8014e0f35b0a"
+                }
+            ],
+            "pid": "36",
+            "name": "한국대학신문",
+            "logoLight": {
+                "url": "https://s.pstatic.net/static/newsstand/2020/logo/light/0604/333.png"
+            },
+            "logoDark": {
+                "url": "https://s.pstatic.net/static/newsstand/2020/logo/dark/0604/333.png"
+            },
+            "regDate": "20230717 11:01:04"
+        },
+        {
+            "materials": [
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "[경인 WIDE] 스토킹은 시작일뿐, 절반이 '추가 범죄' 따라왔다",
+                    "url": "http://www.kyeongin.com/main/view.php?key=20230716010002963",
+                    "aid": "b4973b5aa6a7a21a",
+                    "image": {
+                        "url": "https://s.pstatic.net/dthumb.phinf/?src=%22https%3A%2F%2Fs.pstatic.net%2Fstatic%2Fnewsstand%2F2023%2F0716%2Farticle_img%2Fnew_main%2F9068%2F214135_001.jpg%22&type=nf312_208&service=navermain"
+                    },
+                    "_id": "643542ba1f0f6898fc22218f"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "[경인 WIDE] 피해자 의사와 무관하게 처벌 가능 '환영'",
+                    "url": "http://www.kyeongin.com/main/view.php?key=20230716010002964",
+                    "aid": "b4973b5bf4671a1b",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc222190"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "송도 R2 토지매매 수의계약 검토… 경제청·iH '특혜 논란' 불보듯",
+                    "url": "http://www.kyeongin.com/main/view.php?key=20230714010002876",
+                    "aid": "cc04557d184ae3fd",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc222191"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "'양평고속도로 백지화' 경기도·국토부 공개토론하나",
+                    "url": "http://www.kyeongin.com/main/view.php?key=20230716010003117",
+                    "aid": "b497911a5d82bc5a",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc222192"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "국내 첫 자율주행 '판타G버스', 오늘부터 판교 도로서 부르릉",
+                    "url": "http://www.kyeongin.com/main/view.php?key=20230716010003090",
+                    "aid": "b4978e4a3cbf0f0a",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc222193"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "주말내내 전국에 쏟아진 물폭탄… 아직, 남았다",
+                    "url": "http://www.kyeongin.com/main/view.php?key=20230716010003108",
+                    "aid": "b49790fc2ce1307c",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc222194"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "[오래된 가게 '이어가게'] 41년 손맛 '부영선지국'",
+                    "url": "http://www.kyeongin.com/main/view.php?key=20230714010002870",
+                    "aid": "cc04557745ce13f7",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc222195"
+                }
+            ],
+            "pid": "37",
+            "name": "서울파이낸스",
+            "logoLight": {
+                "url": "https://s.pstatic.net/static/newsstand/2020/logo/light/0604/338.png"
+            },
+            "logoDark": {
+                "url": "https://s.pstatic.net/static/newsstand/2020/logo/dark/0604/338.png"
+            },
+            "regDate": "20230716 21:36:43"
+        },
+        {
+            "materials": [
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "“음식 많이 담았다고 손님 쫓아낸 한식뷔페, 제가 한번 가봤습니다” (+리얼 후기)",
+                    "url": "https://www.wikitree.co.kr/articles/870491",
+                    "aid": "652a000743ea3699",
+                    "image": {
+                        "url": "https://s.pstatic.net/dthumb.phinf/?src=%22https%3A%2F%2Fs.pstatic.net%2Fstatic%2Fnewsstand%2F2023%2F0717%2Farticle_img%2Fnew_main%2F9157%2F112248_001.jpg%22&type=nf312_208&service=navermain"
+                    },
+                    "_id": "643542ba1f0f6898fc22208c"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "'인천 아파트 칼부림' 흉기 찔린 30대 여성, 결국 사망… 가해자 정체가 밝혀졌다",
+                    "url": "https://www.wikitree.co.kr/articles/870528",
+                    "aid": "652a02f65b95258a",
+                    "image": null,
+                    "_id": "6496996b60f3c014e7a9bccd"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "이혼 후 게시물 모두 삭제…3년 만에 SNS 재개한 여배우, 근황 전했다",
+                    "url": "https://www.wikitree.co.kr/articles/870485",
+                    "aid": "6529ffecb59a97d4",
+                    "image": null,
+                    "_id": "64a9659733520e07dac10f3b"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "'오송 지하차도 침수' 희생자가 올린 페이스북 글... 마음이 찢어집니다",
+                    "url": "https://www.wikitree.co.kr/articles/870487",
+                    "aid": "6529ffee292fdb92",
+                    "image": null,
+                    "_id": "64a9659733520e07dac10f3c"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "“사람이 죽었는데...” 싸이, 비난 속출한 문제의 '흠뻑쇼' 후기 (내용)",
+                    "url": "https://www.wikitree.co.kr/articles/870497",
+                    "aid": "652a000d9eaa01d3",
+                    "image": null,
+                    "_id": "64b0dbfc548a597b72d3cdf3"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "'나는 자연인이다' 출연자, 경북 예천 산사태로 실종…아내는 숨진 채 발견",
+                    "url": "https://www.wikitree.co.kr/articles/870449",
+                    "aid": "6529ff74c6dc864c",
+                    "image": null,
+                    "_id": "64b0dbfc548a597b72d3cdf4"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "5월 결혼한 새신랑…'30살' 초등교사, 오송 지하차도 침수사고로 세상 떠났다",
+                    "url": "https://www.wikitree.co.kr/articles/870426",
+                    "aid": "6529ff332e88542d",
+                    "image": null,
+                    "_id": "64b0dbfc548a597b72d3cdf5"
+                }
+            ],
+            "pid": "38",
+            "name": "엑스포스뉴스",
+            "logoLight": {
+                "url": "https://s.pstatic.net/static/newsstand/2020/logo/light/0604/539.png"
+            },
+            "logoDark": {
+                "url": "https://s.pstatic.net/static/newsstand/2020/logo/dark/0604/539.png"
+            },
+            "regDate": "20230717 11:22:20"
+        },
+        {
+            "materials": [
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "송지효, 재벌 2세설의 진실 \"부모님은 부모님, 나는 나\"",
+                    "url": "https://tenasia.hankyung.com/tv-drama/article/2023071701774?utm_source=naver&utm_medium=naver_newsstandcast&utm_campaign=newsstandcast_naver_all",
+                    "aid": "fe81dc38bf74d7c8",
+                    "image": {
+                        "url": "https://s.pstatic.net/dthumb.phinf/?src=%22https%3A%2F%2Fs.pstatic.net%2Fstatic%2Fnewsstand%2F2023%2F0717%2Farticle_img%2Fnew_main%2F9051%2F090303_001.jpg%22&type=nf312_208&service=navermain"
+                    },
+                    "_id": "643542ba1f0f6898fc2220bd"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "이상민, 69억 빚 청산하면 뭐하나…\"자가 아닌 월세\"",
+                    "url": "https://tenasia.hankyung.com/tv-drama/article/2023071702374?utm_source=naver&utm_medium=naver_newsstandcast&utm_campaign=newsstandcast_naver_all",
+                    "aid": "5e1d45bd85753663",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc2220be"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "'공개 열애 2회' 전현무, '연애 전문가'였네…능수능란",
+                    "url": "https://tenasia.hankyung.com/tv-drama/article/2023071702744?utm_source=naver&utm_medium=naver_newsstandcast&utm_campaign=newsstandcast_naver_all",
+                    "aid": "9bf46d76d8903bca",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc2220bf"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "10기 현숙♥영철, 재혼 앞두고 결별설…\"시간 가져\"",
+                    "url": "https://tenasia.hankyung.com/topic/article/2023071702814?utm_source=naver&utm_medium=naver_newsstandcast&utm_campaign=newsstandcast_naver_all",
+                    "aid": "334c772f047a946f",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc2220c0"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "송혜교·아이유→김우빈♥신민아, '때 안가리는' 기부",
+                    "url": "https://tenasia.hankyung.com/topic/article/2023071703114?utm_source=naver&utm_medium=naver_newsstandcast&utm_campaign=newsstandcast_naver_all",
+                    "aid": "6bd69c17eb15d197",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc2220c1"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "이은지 \"택시기사 父, 남친과 외박 여행에 데려다줘\"",
+                    "url": "https://tenasia.hankyung.com/tv-drama/article/2023071701784?utm_source=naver&utm_medium=naver_newsstandcast&utm_campaign=newsstandcast_naver_all",
+                    "aid": "6d08ed793dd5dba7",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc2220c2"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "'김지민♥' 김준호, 철철 흐르는 바람기? '당황'",
+                    "url": "https://tenasia.hankyung.com/topic/article/2023071702794?utm_source=naver&utm_medium=naver_newsstandcast&utm_campaign=newsstandcast_naver_all",
+                    "aid": "4529ea58d223cd18",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc2220c3"
+                }
+            ],
+            "pid": "39",
+            "name": "맥스무비",
+            "logoLight": {
+                "url": "https://s.pstatic.net/static/newsstand/2020/logo/light/0604/312.png"
+            },
+            "logoDark": {
+                "url": "https://s.pstatic.net/static/newsstand/2020/logo/dark/0604/312.png"
+            },
+            "regDate": "20230717 08:56:59"
+        },
+        {
+            "materials": [
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "제주도, 노후 차집관로 2026년까지 전면 교체",
+                    "url": "http://www.jejudomin.co.kr/news/articleView.html?idxno=218066",
+                    "aid": "16dfd360b7561820",
+                    "image": {
+                        "url": "https://s.pstatic.net/dthumb.phinf/?src=%22https%3A%2F%2Fs.pstatic.net%2Fstatic%2Fnewsstand%2F2023%2F0717%2Farticle_img%2Fnew_main%2F9099%2F112920_001.jpg%22&type=nf312_208&service=navermain"
+                    },
+                    "_id": "643542ba1f0f6898fc221db4"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "제주도의회, 강경흠 의원 징계 착수…사퇴 요구 잇따라",
+                    "url": "http://www.jejudomin.co.kr/news/articleView.html?idxno=218046",
+                    "aid": "16dfd322e2f707e2",
+                    "image": null,
+                    "_id": "64af13a4548a597b72d3604a"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "제주도 ‘공공주도 2.0 풍력 조례’ 의회서 ‘제동’",
+                    "url": "http://www.jejudomin.co.kr/news/articleView.html?idxno=218022",
+                    "aid": "16dfd2e09f9208a0",
+                    "image": null,
+                    "_id": "64af13a4548a597b72d3604b"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "제주 자원순환사회 조성 핵심기반시설 본격 가동",
+                    "url": "http://www.jejudomin.co.kr/news/articleView.html?idxno=218057",
+                    "aid": "16dfd34228e80bc2",
+                    "image": null,
+                    "_id": "64b02a1363b70c6ebed54bff"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "양파·당근 과잉생산 우려...10% 이상 감축 필요",
+                    "url": "http://www.jejudomin.co.kr/news/articleView.html?idxno=218055",
+                    "aid": "16dfd34071651440",
+                    "image": null,
+                    "_id": "64b14b113c50cd9912fcde86"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "제주, 동물등록 8.7% 늘고↑...유기동물 11.8% 감소↓",
+                    "url": "http://www.jejudomin.co.kr/news/articleView.html?idxno=218054",
+                    "aid": "16dfd33f95a3987f",
+                    "image": null,
+                    "_id": "64b14b113c50cd9912fcde87"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "제주 마을관광 브랜드 ‘카름스테이’ 3곳 신규 선정",
+                    "url": "http://www.jejudomin.co.kr/news/articleView.html?idxno=218045",
+                    "aid": "16dfd32107358c21",
+                    "image": null,
+                    "_id": "64b284a8e82d6f14f22b4cc4"
+                }
+            ],
+            "pid": "40",
+            "name": "OBS",
+            "logoLight": {
+                "url": "https://s.pstatic.net/static/newsstand/2020/logo/light/0604/389.png"
+            },
+            "logoDark": {
+                "url": "https://s.pstatic.net/static/newsstand/2020/logo/dark/0604/389.png"
+            },
+            "regDate": "20230717 11:20:37"
+        },
+        {
+            "materials": [
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "[포커스 인터뷰] 동서대학교 디자인대학 석좌교수 이코 밀리오레",
+                    "url": "https://www.jungle.co.kr/magazine/205389",
+                    "aid": "277300fef522d282",
+                    "image": {
+                        "url": "https://s.pstatic.net/dthumb.phinf/?src=%22https%3A%2F%2Fs.pstatic.net%2Fstatic%2Fnewsstand%2F2023%2F0716%2Farticle_img%2Fnew_main%2F9077%2F183358_001.jpeg%22&type=nf312_208&service=navermain"
+                    },
+                    "_id": "643542ba1f0f6898fc2221ab"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "[전시 포커스] 가평꽃동네 희망의집 다림 작가들의 ‘2023 여름이야기’",
+                    "url": "https://www.jungle.co.kr/magazine/205388",
+                    "aid": "277300fd3bab44e3",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc2221ac"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "[디자인 이슈] 글자의 힘 보여주는 글로벌 타이포그래피 챌린지, ‘타이포그래피 오디세이: 2023 외솔국제타이포그래피 공모전’ ",
+                    "url": "https://www.jungle.co.kr/magazine/205379",
+                    "aid": "277300df5a821001",
+                    "image": null,
+                    "_id": "6445205d6e592107d2d0e2b1"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "[포커스 인터뷰] 사회를 위한 디자인 계획하는 (사)한국산업디자이너협회 한경하 회장",
+                    "url": "https://www.jungle.co.kr/magazine/205378",
+                    "aid": "277300dea10a8262",
+                    "image": null,
+                    "_id": "6445205d6e592107d2d0e2b2"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "[포커스 인터뷰] 디자인 교육의 새로운 방향 쓴 ‘아이덱’, 최인숙 조직위원장 ",
+                    "url": "https://www.jungle.co.kr/magazine/205362",
+                    "aid": "277300b9ad9c6e27",
+                    "image": null,
+                    "_id": "645635d040d2947ae41be558"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "[포커스 인터뷰] ‘공감과 공생’ 추구하는 에피그램 로컬프로젝트 ",
+                    "url": "https://www.jungle.co.kr/magazine/205361",
+                    "aid": "277300b8f424e088",
+                    "image": null,
+                    "_id": "645635d040d2947ae41be559"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "[포커스 인터뷰] 디자이너에서 글을 쓰는 작가로, 디자이너 출신 작가 김운기 ",
+                    "url": "https://www.jungle.co.kr/magazine/205360",
+                    "aid": "277300b73aad52e9",
+                    "image": null,
+                    "_id": "645635d040d2947ae41be55a"
+                }
+            ],
+            "pid": "41",
+            "name": "소년한국일보",
+            "logoLight": {
+                "url": "https://s.pstatic.net/static/newsstand/2020/logo/light/0604/345.png"
+            },
+            "logoDark": {
+                "url": "https://s.pstatic.net/static/newsstand/2020/logo/dark/0604/345.png"
+            },
+            "regDate": "20230716 18:27:27"
+        },
+        {
+            "materials": [
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "윤 대통령 \"특별재난지역 선포 등 정책 모두 동원\"",
+                    "url": "http://www.obsnews.co.kr/news/articleView.html?idxno=1406756",
+                    "aid": "20cbda31ed1c2f6f",
+                    "image": {
+                        "url": "https://s.pstatic.net/dthumb.phinf/?src=%22https%3A%2F%2Fs.pstatic.net%2Fstatic%2Fnewsstand%2F2023%2F0717%2Farticle_img%2Fnew_main%2F9070%2F104113_001.jpg%22&type=nf312_208&service=navermain"
+                    },
+                    "_id": "643542ba1f0f6898fc22219d"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "아파트 복도서 흉기 난동…1명 사망·1명 경상",
+                    "url": "http://www.obsnews.co.kr/news/articleView.html?idxno=1406750",
+                    "aid": "20cbda2b6ffefeb5",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc22219e"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "바다에 아내 빠트리고 돌 던져 살해…30대 구속영장",
+                    "url": "http://www.obsnews.co.kr/news/articleView.html?idxno=1406758",
+                    "aid": "20cbda33c17b3fad",
+                    "image": null,
+                    "_id": "64868b31c499cc07f341f2da"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "경기도·융기원·경기대·장비업체 '반도체 공유대학'",
+                    "url": "http://www.obsnews.co.kr/news/articleView.html?idxno=1406749",
+                    "aid": "20cbda15ddeb4fcb",
+                    "image": null,
+                    "_id": "64868b31c499cc07f341f2db"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "\"호우 사망·실종 48명\"…집계 외 사망자 1명 늘어",
+                    "url": "http://www.obsnews.co.kr/news/articleView.html?idxno=1406757",
+                    "aid": "20cbda32574bb78e",
+                    "image": null,
+                    "_id": "64868b31c499cc07f341f2dc"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "코레일, 경강선 세종대왕릉~여주 구간 운행 재개",
+                    "url": "http://www.obsnews.co.kr/news/articleView.html?idxno=1406730",
+                    "aid": "20cbd9edd4800eb3",
+                    "image": null,
+                    "_id": "64868b31c499cc07f341f2dd"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "국회 법사위, 오늘 '영아살해·유기 처벌강화법' 처리",
+                    "url": "http://www.obsnews.co.kr/news/articleView.html?idxno=1406727",
+                    "aid": "20cbd9d56e0d4f8b",
+                    "image": null,
+                    "_id": "64a67a2a3e93486eac6d4ead"
+                }
+            ],
+            "pid": "42",
+            "name": "한국일보",
+            "logoLight": {
+                "url": "https://s.pstatic.net/static/newsstand/2020/logo/light/0604/340.png"
+            },
+            "logoDark": {
+                "url": "https://s.pstatic.net/static/newsstand/2020/logo/dark/0604/340.png"
+            },
+            "regDate": "20230717 10:37:44"
+        },
+        {
+            "materials": [
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "[경인 WIDE] 스토킹은 시작일뿐, 절반이 '추가 범죄' 따라왔다",
+                    "url": "http://www.kyeongin.com/main/view.php?key=20230716010002963",
+                    "aid": "b4973b5aa6a7a21a",
+                    "image": {
+                        "url": "https://s.pstatic.net/dthumb.phinf/?src=%22https%3A%2F%2Fs.pstatic.net%2Fstatic%2Fnewsstand%2F2023%2F0716%2Farticle_img%2Fnew_main%2F9068%2F214135_001.jpg%22&type=nf312_208&service=navermain"
+                    },
+                    "_id": "643542ba1f0f6898fc22218f"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "[경인 WIDE] 피해자 의사와 무관하게 처벌 가능 '환영'",
+                    "url": "http://www.kyeongin.com/main/view.php?key=20230716010002964",
+                    "aid": "b4973b5bf4671a1b",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc222190"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "송도 R2 토지매매 수의계약 검토… 경제청·iH '특혜 논란' 불보듯",
+                    "url": "http://www.kyeongin.com/main/view.php?key=20230714010002876",
+                    "aid": "cc04557d184ae3fd",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc222191"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "'양평고속도로 백지화' 경기도·국토부 공개토론하나",
+                    "url": "http://www.kyeongin.com/main/view.php?key=20230716010003117",
+                    "aid": "b497911a5d82bc5a",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc222192"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "국내 첫 자율주행 '판타G버스', 오늘부터 판교 도로서 부르릉",
+                    "url": "http://www.kyeongin.com/main/view.php?key=20230716010003090",
+                    "aid": "b4978e4a3cbf0f0a",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc222193"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "주말내내 전국에 쏟아진 물폭탄… 아직, 남았다",
+                    "url": "http://www.kyeongin.com/main/view.php?key=20230716010003108",
+                    "aid": "b49790fc2ce1307c",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc222194"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "[오래된 가게 '이어가게'] 41년 손맛 '부영선지국'",
+                    "url": "http://www.kyeongin.com/main/view.php?key=20230714010002870",
+                    "aid": "cc04557745ce13f7",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc222195"
+                }
+            ],
+            "pid": "43",
+            "name": "Sportal korea",
+            "logoLight": {
+                "url": "https://s.pstatic.net/static/newsstand/2020/logo/light/0604/338.png"
+            },
+            "logoDark": {
+                "url": "https://s.pstatic.net/static/newsstand/2020/logo/dark/0604/338.png"
+            },
+            "regDate": "20230716 21:36:43"
+        },
+        {
+            "materials": [
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "송지효, 재벌 2세설의 진실 \"부모님은 부모님, 나는 나\"",
+                    "url": "https://tenasia.hankyung.com/tv-drama/article/2023071701774?utm_source=naver&utm_medium=naver_newsstandcast&utm_campaign=newsstandcast_naver_all",
+                    "aid": "fe81dc38bf74d7c8",
+                    "image": {
+                        "url": "https://s.pstatic.net/dthumb.phinf/?src=%22https%3A%2F%2Fs.pstatic.net%2Fstatic%2Fnewsstand%2F2023%2F0717%2Farticle_img%2Fnew_main%2F9051%2F090303_001.jpg%22&type=nf312_208&service=navermain"
+                    },
+                    "_id": "643542ba1f0f6898fc2220bd"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "이상민, 69억 빚 청산하면 뭐하나…\"자가 아닌 월세\"",
+                    "url": "https://tenasia.hankyung.com/tv-drama/article/2023071702374?utm_source=naver&utm_medium=naver_newsstandcast&utm_campaign=newsstandcast_naver_all",
+                    "aid": "5e1d45bd85753663",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc2220be"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "'공개 열애 2회' 전현무, '연애 전문가'였네…능수능란",
+                    "url": "https://tenasia.hankyung.com/tv-drama/article/2023071702744?utm_source=naver&utm_medium=naver_newsstandcast&utm_campaign=newsstandcast_naver_all",
+                    "aid": "9bf46d76d8903bca",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc2220bf"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "10기 현숙♥영철, 재혼 앞두고 결별설…\"시간 가져\"",
+                    "url": "https://tenasia.hankyung.com/topic/article/2023071702814?utm_source=naver&utm_medium=naver_newsstandcast&utm_campaign=newsstandcast_naver_all",
+                    "aid": "334c772f047a946f",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc2220c0"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "송혜교·아이유→김우빈♥신민아, '때 안가리는' 기부",
+                    "url": "https://tenasia.hankyung.com/topic/article/2023071703114?utm_source=naver&utm_medium=naver_newsstandcast&utm_campaign=newsstandcast_naver_all",
+                    "aid": "6bd69c17eb15d197",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc2220c1"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "이은지 \"택시기사 父, 남친과 외박 여행에 데려다줘\"",
+                    "url": "https://tenasia.hankyung.com/tv-drama/article/2023071701784?utm_source=naver&utm_medium=naver_newsstandcast&utm_campaign=newsstandcast_naver_all",
+                    "aid": "6d08ed793dd5dba7",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc2220c2"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "'김지민♥' 김준호, 철철 흐르는 바람기? '당황'",
+                    "url": "https://tenasia.hankyung.com/topic/article/2023071702794?utm_source=naver&utm_medium=naver_newsstandcast&utm_campaign=newsstandcast_naver_all",
+                    "aid": "4529ea58d223cd18",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc2220c3"
+                }
+            ],
+            "pid": "44",
+            "name": "아시아경제",
+            "logoLight": {
+                "url": "https://s.pstatic.net/static/newsstand/2020/logo/light/0604/312.png"
+            },
+            "logoDark": {
+                "url": "https://s.pstatic.net/static/newsstand/2020/logo/dark/0604/312.png"
+            },
+            "regDate": "20230717 08:56:59"
+        },
+        {
+            "materials": [
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "英 BBC \"日 오염수 방류에 일본 주민들도 불안 느껴\"",
+                    "url": "https://www.dongascience.com/news.php?idx=60721",
+                    "aid": "7412e17471a2fa34",
+                    "image": {
+                        "url": "https://s.pstatic.net/dthumb.phinf/?src=%22https%3A%2F%2Fs.pstatic.net%2Fstatic%2Fnewsstand%2F2023%2F0717%2Farticle_img%2Fnew_main%2F9086%2F091151_001.jpg%22&type=nf312_208&service=navermain"
+                    },
+                    "_id": "643542ba1f0f6898fc221bbc"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "폭우로 사망 26명, 실종 10명...17일까지 강한 비",
+                    "url": "https://www.dongascience.com/news.php?idx=60719",
+                    "aid": "7412e15dad9febdd",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc221bbd"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "[씨즈더퓨처] 제로슈거의 미래는...'아스파탐' 발암 가능 물질 지정",
+                    "url": "https://www.dongascience.com/news.php?idx=60714",
+                    "aid": "7412e158eb7a7458",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc221bbe"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "[주말N수학] 대구과학고 수학 1등 비결은",
+                    "url": "https://www.dongascience.com/news.php?idx=60703",
+                    "aid": "7412e13830672878",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc221bbf"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "인도, 달 탐사선 '찬드라얀 3호' 발사 성공...내달 23일 달 착륙 예상",
+                    "url": "https://www.dongascience.com/news.php?idx=60720",
+                    "aid": "7412e173e46848b3",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc221bc0"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "체온으로 센서 구동한다...에너지 하베스터 3D프린팅 개발",
+                    "url": "https://www.dongascience.com/news.php?idx=60722",
+                    "aid": "7412e175feddabb5",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc221bc1"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "생성형AI의 시대… '전문가' 인간은 살아남을까",
+                    "url": "https://www.dongascience.com/news.php?idx=60677",
+                    "aid": "7412de5462b30954",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc221bc2"
+                }
+            ],
+            "pid": "45",
+            "name": "프레시안",
+            "logoLight": {
+                "url": "https://s.pstatic.net/static/newsstand/2020/logo/light/0604/363.png"
+            },
+            "logoDark": {
+                "url": "https://s.pstatic.net/static/newsstand/2020/logo/dark/0604/363.png"
+            },
+            "regDate": "20230717 09:06:20"
+        },
+        {
+            "materials": [
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "민주당 개그, 2000년 뒤까지 책임지라고 하지!",
+                    "url": "https://www.dailian.co.kr/news/view/1253750/?sc=Naver",
+                    "aid": "d6c970665deb0aa6",
+                    "image": {
+                        "url": "https://s.pstatic.net/dthumb.phinf/?src=%22https%3A%2F%2Fs.pstatic.net%2Fstatic%2Fnewsstand%2F2023%2F0717%2Farticle_img%2Fnew_main%2F9090%2F112248_001.jpg%22&type=nf312_208&service=navermain"
+                    },
+                    "_id": "643542ba1f0f6898fc221bfb"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "윤 대통령 \"비통한 마음…특별재난지역 선포 등 정책 모두 동원\"",
+                    "url": "https://www.dailian.co.kr/news/view/1253856/?sc=Naver",
+                    "aid": "42a8a76dd09ecced",
+                    "image": null,
+                    "_id": "64aa8f3b40d2947ae42c0399"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "검찰, 박영수의 \"변협회장 선거 자금 문제 될 수 있다\" 메모 확보…측근 변호사들 줄소환",
+                    "url": "https://www.dailian.co.kr/news/view/1253766/?sc=Naver",
+                    "aid": "5bd7464b94ef488b",
+                    "image": null,
+                    "_id": "64aa8f3b40d2947ae42c039a"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "탄탄한 성장 기반…수익성·여신건전성 모두 '톱' [우리금융 퀀텀점프①]",
+                    "url": "https://www.dailian.co.kr/news/view/1253208/?sc=Naver",
+                    "aid": "aee7ab0eeddff20e",
+                    "image": null,
+                    "_id": "64aa8f3b40d2947ae42c039b"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "\"韓, 4대 방산강국 도약 시 매출·고용 2배 증가…맞춤 수출전략 짜야\"",
+                    "url": "https://www.dailian.co.kr/news/view/1253657/?sc=Naver",
+                    "aid": "fa874d2ce5341a6c",
+                    "image": null,
+                    "_id": "64aa8f3b40d2947ae42c039c"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "'최대 채권자' 서울보증, 명지학원 기업회생계획 통과시켰다",
+                    "url": "https://www.dailian.co.kr/news/view/1253847/?sc=Naver",
+                    "aid": "cfdbb4cf965dc50f",
+                    "image": null,
+                    "_id": "64aa8f3b40d2947ae42c039d"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "경찰, '오송 지하차도 참사' 전담팀 구성…\"책임 소재 본격 수사\"",
+                    "url": "https://www.dailian.co.kr/news/view/1253867/?sc=Naver",
+                    "aid": "df3eff8d09f308cd",
+                    "image": null,
+                    "_id": "64aa8f3b40d2947ae42c039e"
+                }
+            ],
+            "pid": "46",
+            "name": "노컷뉴스",
+            "logoLight": {
+                "url": "https://s.pstatic.net/static/newsstand/2020/logo/light/0604/368.png"
+            },
+            "logoDark": {
+                "url": "https://s.pstatic.net/static/newsstand/2020/logo/dark/0604/368.png"
+            },
+            "regDate": "20230717 11:17:17"
+        }
+    ],
+    "5": [
+        {
+            "materials": [
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "英 BBC \"日 오염수 방류에 일본 주민들도 불안 느껴\"",
+                    "url": "https://www.dongascience.com/news.php?idx=60721",
+                    "aid": "7412e17471a2fa34",
+                    "image": {
+                        "url": "https://s.pstatic.net/dthumb.phinf/?src=%22https%3A%2F%2Fs.pstatic.net%2Fstatic%2Fnewsstand%2F2023%2F0717%2Farticle_img%2Fnew_main%2F9086%2F091151_001.jpg%22&type=nf312_208&service=navermain"
+                    },
+                    "_id": "643542ba1f0f6898fc221bbc"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "폭우로 사망 26명, 실종 10명...17일까지 강한 비",
+                    "url": "https://www.dongascience.com/news.php?idx=60719",
+                    "aid": "7412e15dad9febdd",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc221bbd"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "[씨즈더퓨처] 제로슈거의 미래는...'아스파탐' 발암 가능 물질 지정",
+                    "url": "https://www.dongascience.com/news.php?idx=60714",
+                    "aid": "7412e158eb7a7458",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc221bbe"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "[주말N수학] 대구과학고 수학 1등 비결은",
+                    "url": "https://www.dongascience.com/news.php?idx=60703",
+                    "aid": "7412e13830672878",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc221bbf"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "인도, 달 탐사선 '찬드라얀 3호' 발사 성공...내달 23일 달 착륙 예상",
+                    "url": "https://www.dongascience.com/news.php?idx=60720",
+                    "aid": "7412e173e46848b3",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc221bc0"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "체온으로 센서 구동한다...에너지 하베스터 3D프린팅 개발",
+                    "url": "https://www.dongascience.com/news.php?idx=60722",
+                    "aid": "7412e175feddabb5",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc221bc1"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "생성형AI의 시대… '전문가' 인간은 살아남을까",
+                    "url": "https://www.dongascience.com/news.php?idx=60677",
+                    "aid": "7412de5462b30954",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc221bc2"
+                }
+            ],
+            "pid": "47",
+            "name": "중앙일보",
+            "logoLight": {
+                "url": "https://s.pstatic.net/static/newsstand/2020/logo/light/0604/363.png"
+            },
+            "logoDark": {
+                "url": "https://s.pstatic.net/static/newsstand/2020/logo/dark/0604/363.png"
+            },
+            "regDate": "20230717 09:06:20"
+        },
+        {
+            "materials": [
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "[경인 WIDE] 스토킹은 시작일뿐, 절반이 '추가 범죄' 따라왔다",
+                    "url": "http://www.kyeongin.com/main/view.php?key=20230716010002963",
+                    "aid": "b4973b5aa6a7a21a",
+                    "image": {
+                        "url": "https://s.pstatic.net/dthumb.phinf/?src=%22https%3A%2F%2Fs.pstatic.net%2Fstatic%2Fnewsstand%2F2023%2F0716%2Farticle_img%2Fnew_main%2F9068%2F214135_001.jpg%22&type=nf312_208&service=navermain"
+                    },
+                    "_id": "643542ba1f0f6898fc22218f"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "[경인 WIDE] 피해자 의사와 무관하게 처벌 가능 '환영'",
+                    "url": "http://www.kyeongin.com/main/view.php?key=20230716010002964",
+                    "aid": "b4973b5bf4671a1b",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc222190"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "송도 R2 토지매매 수의계약 검토… 경제청·iH '특혜 논란' 불보듯",
+                    "url": "http://www.kyeongin.com/main/view.php?key=20230714010002876",
+                    "aid": "cc04557d184ae3fd",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc222191"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "'양평고속도로 백지화' 경기도·국토부 공개토론하나",
+                    "url": "http://www.kyeongin.com/main/view.php?key=20230716010003117",
+                    "aid": "b497911a5d82bc5a",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc222192"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "국내 첫 자율주행 '판타G버스', 오늘부터 판교 도로서 부르릉",
+                    "url": "http://www.kyeongin.com/main/view.php?key=20230716010003090",
+                    "aid": "b4978e4a3cbf0f0a",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc222193"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "주말내내 전국에 쏟아진 물폭탄… 아직, 남았다",
+                    "url": "http://www.kyeongin.com/main/view.php?key=20230716010003108",
+                    "aid": "b49790fc2ce1307c",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc222194"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "[오래된 가게 '이어가게'] 41년 손맛 '부영선지국'",
+                    "url": "http://www.kyeongin.com/main/view.php?key=20230714010002870",
+                    "aid": "cc04557745ce13f7",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc222195"
+                }
+            ],
+            "pid": "48",
+            "name": "서울신문",
+            "logoLight": {
+                "url": "https://s.pstatic.net/static/newsstand/2020/logo/light/0604/338.png"
+            },
+            "logoDark": {
+                "url": "https://s.pstatic.net/static/newsstand/2020/logo/dark/0604/338.png"
+            },
+            "regDate": "20230716 21:36:43"
+        },
+        {
+            "materials": [
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "윤 대통령 \"특별재난지역 선포 등 정책 모두 동원\"",
+                    "url": "http://www.obsnews.co.kr/news/articleView.html?idxno=1406756",
+                    "aid": "20cbda31ed1c2f6f",
+                    "image": {
+                        "url": "https://s.pstatic.net/dthumb.phinf/?src=%22https%3A%2F%2Fs.pstatic.net%2Fstatic%2Fnewsstand%2F2023%2F0717%2Farticle_img%2Fnew_main%2F9070%2F104113_001.jpg%22&type=nf312_208&service=navermain"
+                    },
+                    "_id": "643542ba1f0f6898fc22219d"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "아파트 복도서 흉기 난동…1명 사망·1명 경상",
+                    "url": "http://www.obsnews.co.kr/news/articleView.html?idxno=1406750",
+                    "aid": "20cbda2b6ffefeb5",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc22219e"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "바다에 아내 빠트리고 돌 던져 살해…30대 구속영장",
+                    "url": "http://www.obsnews.co.kr/news/articleView.html?idxno=1406758",
+                    "aid": "20cbda33c17b3fad",
+                    "image": null,
+                    "_id": "64868b31c499cc07f341f2da"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "경기도·융기원·경기대·장비업체 '반도체 공유대학'",
+                    "url": "http://www.obsnews.co.kr/news/articleView.html?idxno=1406749",
+                    "aid": "20cbda15ddeb4fcb",
+                    "image": null,
+                    "_id": "64868b31c499cc07f341f2db"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "\"호우 사망·실종 48명\"…집계 외 사망자 1명 늘어",
+                    "url": "http://www.obsnews.co.kr/news/articleView.html?idxno=1406757",
+                    "aid": "20cbda32574bb78e",
+                    "image": null,
+                    "_id": "64868b31c499cc07f341f2dc"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "코레일, 경강선 세종대왕릉~여주 구간 운행 재개",
+                    "url": "http://www.obsnews.co.kr/news/articleView.html?idxno=1406730",
+                    "aid": "20cbd9edd4800eb3",
+                    "image": null,
+                    "_id": "64868b31c499cc07f341f2dd"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "국회 법사위, 오늘 '영아살해·유기 처벌강화법' 처리",
+                    "url": "http://www.obsnews.co.kr/news/articleView.html?idxno=1406727",
+                    "aid": "20cbd9d56e0d4f8b",
+                    "image": null,
+                    "_id": "64a67a2a3e93486eac6d4ead"
+                }
+            ],
+            "pid": "49",
+            "name": "스포츠조선",
+            "logoLight": {
+                "url": "https://s.pstatic.net/static/newsstand/2020/logo/light/0604/340.png"
+            },
+            "logoDark": {
+                "url": "https://s.pstatic.net/static/newsstand/2020/logo/dark/0604/340.png"
+            },
+            "regDate": "20230717 10:37:44"
+        },
+        {
+            "materials": [
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "[여론조사]  인천시민 46.7% “유정복 시장 잘하고 있다”",
+                    "url": "https://www.incheonilbo.com/news/articleView.html?idxno=1203079",
+                    "aid": "284d86dd9e09acdd",
+                    "image": {
+                        "url": "https://s.pstatic.net/dthumb.phinf/?src=%22https%3A%2F%2Fs.pstatic.net%2Fstatic%2Fnewsstand%2F2023%2F0717%2Farticle_img%2Fnew_main%2F9097%2F112248_001.jpg%22&type=nf312_208&service=navermain"
+                    },
+                    "_id": "643542ba1f0f6898fc221d9f"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "[여론조사] 김동연 경기지사 지지율 급상승…“잘한다” 57.1%",
+                    "url": "https://www.incheonilbo.com/news/articleView.html?idxno=1203082",
+                    "aid": "284d86f5a13cbcb5",
+                    "image": null,
+                    "_id": "64aa5830d509cf07e8701c29"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "[여론조사] 인천시민·경기도민 윤석열 대통령 국정수행 평가",
+                    "url": "https://www.incheonilbo.com/news/articleView.html?idxno=1203075",
+                    "aid": "284d86d9d8c36ed9",
+                    "image": null,
+                    "_id": "64ab9b5df04b5ed2c5434f2b"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "[여론조사] 경기도민·인천시민 정당 지지도…민주당·국민의힘, 오차범위 내 '엎치락뒤치락'",
+                    "url": "https://www.incheonilbo.com/news/articleView.html?idxno=1203074",
+                    "aid": "284d86d8e771df58",
+                    "image": null,
+                    "_id": "64ab9b5df04b5ed2c5434f2c"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "[여론조사] 내년 총선, 인천시민은 변화 바란다",
+                    "url": "https://www.incheonilbo.com/news/articleView.html?idxno=1203077",
+                    "aid": "284d86dbbb668ddb",
+                    "image": null,
+                    "_id": "64ab9b5df04b5ed2c5434f2d"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "[여론조사] 내년 총선, 경기도민은 변화 바란다…지역 국회의원 '물갈이' 원해",
+                    "url": "https://www.incheonilbo.com/news/articleView.html?idxno=1203078",
+                    "aid": "284d86dcacb81d5c",
+                    "image": null,
+                    "_id": "64b3d1f51f0f6898fc3a224d"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "[창간 35주년 여론조사] 김동연 경기지사 지지율 급상승 이유…철도망 확충·민생경제 주 요인",
+                    "url": "https://www.incheonilbo.com/news/articleView.html?idxno=1203092",
+                    "aid": "284d87143daab914",
+                    "image": null,
+                    "_id": "64b3d1f51f0f6898fc3a224e"
+                }
+            ],
+            "pid": "50",
+            "name": "전자신문",
+            "logoLight": {
+                "url": "https://s.pstatic.net/static/newsstand/up/2022/0331/nsd155937506.png"
+            },
+            "logoDark": {
+                "url": "https://s.pstatic.net/static/newsstand/up/2022/0331/nsd15594915.png"
+            },
+            "regDate": "20230717 11:20:04"
+        },
+        {
+            "materials": [
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "Death toll from rains at 40 with 13 killed in flooded tunnel",
+                    "url": "https://koreajoongangdaily.joins.com/2023/07/17/national/socialAffairs/osong-underpass-heavy-rain/20230717093506335.html",
+                    "aid": "effadea33b4a4f3d",
+                    "image": {
+                        "url": "https://s.pstatic.net/dthumb.phinf/?src=%22https%3A%2F%2Fs.pstatic.net%2Fstatic%2Fnewsstand%2F2023%2F0717%2Farticle_img%2Fnew_main%2F9061%2F105218_001.jpg%22&type=nf312_208&service=navermain"
+                    },
+                    "_id": "643542ba1f0f6898fc222142"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "Yoon orders all-out support to heavy rains",
+                    "url": "https://koreajoongangdaily.joins.com/2023/07/17/national/politics/Korea-Yoon-Suk-Yeol-rain/20230717102737010.html",
+                    "aid": "f0bfa83495337cf4",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc222143"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "Hyundai Motor begins comeback in China",
+                    "url": "https://koreajoongangdaily.joins.com/2023/07/15/business/industry/korea-china-ioniq-n/20230715070013188.html",
+                    "aid": "057a6fdfb5cfff01",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc222144"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "Over 45 people dead, missing across Korea as monsoon season rages",
+                    "url": "https://koreajoongangdaily.joins.com/2023/07/16/national/socialAffairs/korea-monsoon-rain/20230716185100715.html",
+                    "aid": "36049e19ef4d3a07",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc222145"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "Flood waters devastate residents in North Chungcheong",
+                    "url": "https://koreajoongangdaily.joins.com/2023/07/16/national/socialAffairs/Osong-underpass-torrential-rain/20230716165509045.html",
+                    "aid": "2306d145b483c105",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc222146"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "Yoon pledges security, humanitarian and reconstruction aid to Ukraine",
+                    "url": "https://koreajoongangdaily.joins.com/2023/07/16/national/diplomacy/Korea-Ukraine-bilateral-summit/20230716152427658.html",
+                    "aid": "2657b1bcd528d8c4",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc222147"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "[THINK ENGLISH] SSG 랜더스 2군 선수들, 폭행 사건 연루",
+                    "url": "https://koreajoongangdaily.joins.com/2023/07/17/sports/Baseball/THINK-ENGLISH-SSG-Landers-physical-abuse/20230717093326353.html",
+                    "aid": "31b05a78de3c2e38",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc222148"
+                }
+            ],
+            "pid": "51",
+            "name": "한국경제TV",
+            "logoLight": {
+                "url": "https://s.pstatic.net/static/newsstand/2020/logo/light/0604/330.png"
+            },
+            "logoDark": {
+                "url": "https://s.pstatic.net/static/newsstand/2020/logo/dark/0604/330.png"
+            },
+            "regDate": "20230717 10:43:52"
+        },
+        {
+            "materials": [
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "“음식 많이 담았다고 손님 쫓아낸 한식뷔페, 제가 한번 가봤습니다” (+리얼 후기)",
+                    "url": "https://www.wikitree.co.kr/articles/870491",
+                    "aid": "652a000743ea3699",
+                    "image": {
+                        "url": "https://s.pstatic.net/dthumb.phinf/?src=%22https%3A%2F%2Fs.pstatic.net%2Fstatic%2Fnewsstand%2F2023%2F0717%2Farticle_img%2Fnew_main%2F9157%2F113134_001.jpg%22&type=nf312_208&service=navermain"
+                    },
+                    "_id": "643542ba1f0f6898fc22208c"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "금수저 맞습니다...런닝맨 송지효 아버지 직업, '이 업체' 대표이사다",
+                    "url": "https://www.wikitree.co.kr/articles/870531",
+                    "aid": "652a030e3c84deb2",
+                    "image": null,
+                    "_id": "6496996b60f3c014e7a9bccd"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "'인천 아파트 칼부림' 흉기 찔린 30대 여성, 결국 사망… 가해자 정체가 밝혀졌다",
+                    "url": "https://www.wikitree.co.kr/articles/870528",
+                    "aid": "652a02f65b95258a",
+                    "image": null,
+                    "_id": "64a9659733520e07dac10f3b"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "이혼 후 게시물 모두 삭제…3년 만에 SNS 재개한 여배우, 근황 전했다",
+                    "url": "https://www.wikitree.co.kr/articles/870485",
+                    "aid": "6529ffecb59a97d4",
+                    "image": null,
+                    "_id": "64a9659733520e07dac10f3c"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "'오송 지하차도 침수' 희생자가 올린 페이스북 글... 마음이 찢어집니다",
+                    "url": "https://www.wikitree.co.kr/articles/870487",
+                    "aid": "6529ffee292fdb92",
+                    "image": null,
+                    "_id": "64b0dbfc548a597b72d3cdf3"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "'나는 자연인이다' 출연자, 경북 예천 산사태로 실종…아내는 숨진 채 발견",
+                    "url": "https://www.wikitree.co.kr/articles/870449",
+                    "aid": "6529ff74c6dc864c",
+                    "image": null,
+                    "_id": "64b0dbfc548a597b72d3cdf4"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "5월 결혼한 새신랑…'30살' 초등교사, 오송 지하차도 침수사고로 세상 떠났다",
+                    "url": "https://www.wikitree.co.kr/articles/870426",
+                    "aid": "6529ff332e88542d",
+                    "image": null,
+                    "_id": "64b0dbfc548a597b72d3cdf5"
+                }
+            ],
+            "pid": "52",
+            "name": "BLOTER",
+            "logoLight": {
+                "url": "https://s.pstatic.net/static/newsstand/2020/logo/light/0604/539.png"
+            },
+            "logoDark": {
+                "url": "https://s.pstatic.net/static/newsstand/2020/logo/dark/0604/539.png"
+            },
+            "regDate": "20230717 11:31:07"
+        },
+        {
+            "materials": [
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "우주 ‘식집사’는 빛 대신 이산화탄소로 식물을 키운다?",
+                    "url": "https://www.sciencetimes.co.kr/?news=%ec%9a%b0%ec%a3%bc-%ec%8b%9d%ec%a7%91%ec%82%ac%eb%8a%94-%eb%b9%9b-%eb%8c%80%ec%8b%a0-%ec%9d%b4%ec%82%b0%ed%99%94%ed%83%84%ec%86%8c%eb%a1%9c-%ec%8b%9d%eb%ac%bc%ec%9d%84-%ed%82%a4",
+                    "aid": "bda852ce55333fb2",
+                    "image": {
+                        "url": "https://s.pstatic.net/dthumb.phinf/?src=%22https%3A%2F%2Fs.pstatic.net%2Fstatic%2Fnewsstand%2F2023%2F0717%2Farticle_img%2Fnew_main%2F9081%2F111451_001.jpg%22&type=nf312_208&service=navermain"
+                    },
+                    "_id": "643542ba1f0f6898fc221b5a"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "인종 장벽 없앤 인간 ‘판게놈 참조 지도’ 초안 나왔다",
+                    "url": "https://www.sciencetimes.co.kr/?news=%ec%9d%b8%ec%a2%85-%ec%9e%a5%eb%b2%bd-%ec%97%86%ec%95%a4-%ec%9d%b8%ea%b0%84-%ed%8c%90%ea%b2%8c%eb%86%88-%ec%b0%b8%ec%a1%b0-%ec%a7%80%eb%8f%84-%ec%b4%88%ec%95%88-%eb%82%98%ec%99%94",
+                    "aid": "37625c79b7d50867",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc221b5b"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "‘모나리자’의 눈썹, 짙고 두꺼웠을 수도 있다?",
+                    "url": "https://www.sciencetimes.co.kr/?news=%eb%aa%a8%eb%82%98%eb%a6%ac%ec%9e%90%ec%9d%98-%eb%88%88%ec%8d%b9-%ec%a7%99%ea%b3%a0-%eb%91%90%ea%ba%bc%ec%9b%a0%ec%9d%84-%ec%88%98%eb%8f%84-%ec%9e%88%eb%8b%a4",
+                    "aid": "03b0b4d7a107bdd7",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc221b5c"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "제1회 세계 한인 과학기술인 대회 마지막날, 다양한 기조강연과 포럼이 진행되다",
+                    "url": "https://www.sciencetimes.co.kr/?news=%ec%a0%9c1%ed%9a%8c-%ec%84%b8%ea%b3%84-%ed%95%9c%ec%9d%b8-%ea%b3%bc%ed%95%99%ea%b8%b0%ec%88%a0%ec%9d%b8-%eb%8c%80%ed%9a%8c-%eb%a7%88%ec%a7%80%eb%a7%89%eb%82%a0-%eb%8b%a4%ec%96%91%ed%95%9c-%ea%b8%b0",
+                    "aid": "d31ce9d4f683c76c",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc221b5d"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "디지털 헬스케어, 바이오경제 2.0의 핵심으로 도약하나",
+                    "url": "https://www.sciencetimes.co.kr/?news=%eb%94%94%ec%a7%80%ed%84%b8-%ed%97%ac%ec%8a%a4%ec%bc%80%ec%96%b4-%eb%b0%94%ec%9d%b4%ec%98%a4%ea%b2%bd%ec%a0%9c-2-0%ec%9d%98-%ed%95%b5%ec%8b%ac%ec%9c%bc%eb%a1%9c-%eb%8f%84%ec%95%bd%ed%95%98%eb%82%98",
+                    "aid": "6b7c1fd04d7e58b0",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc221b5e"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "“림프관만 20년 넘게 연구한 덕에 150년의 난제 풀었죠”",
+                    "url": "https://www.sciencetimes.co.kr/?p=252189",
+                    "aid": "38b34093f68134cd",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc221b5f"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "로봇 요리사의 ‘특별한 요리 비결’은 유튜브?",
+                    "url": "https://www.sciencetimes.co.kr/?p=252189",
+                    "aid": "38b34093f68134cd",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc221b60"
+                }
+            ],
+            "pid": "53",
+            "name": "KBS",
+            "logoLight": {
+                "url": "https://s.pstatic.net/static/newsstand/2020/logo/light/0604/355.png"
+            },
+            "logoDark": {
+                "url": "https://s.pstatic.net/static/newsstand/2020/logo/dark/0604/355.png"
+            },
+            "regDate": "20230714 10:41:16"
+        },
+        {
+            "materials": [
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "구멍 뚫린 하늘, 경북이 잠겼다",
+                    "url": "http://www.kyongbuk.co.kr/news/articleView.html?idxno=2136962",
+                    "aid": "6cc1d4ca9885ec8a",
+                    "image": {
+                        "url": "https://s.pstatic.net/dthumb.phinf/?src=%22https%3A%2F%2Fs.pstatic.net%2Fstatic%2Fnewsstand%2F2023%2F0717%2Farticle_img%2Fnew_main%2F9067%2F054046_001.jpg%22&type=nf312_208&service=navermain"
+                    },
+                    "_id": "643542ba1f0f6898fc222188"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "[단독] 대구은행, 9월 시중銀 인가 신청…은행장 직속 전담조직·TF 설치",
+                    "url": "http://www.kyongbuk.co.kr/news/articleView.html?idxno=2136964",
+                    "aid": "6cc1d4cc5008e40c",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc222189"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "\"피할 엄두도 못냈다\"…산사태 취약지역 초토화 '속수무책'",
+                    "url": "http://www.kyongbuk.co.kr/news/articleView.html?idxno=2136955",
+                    "aid": "6cc1d4aec19ad7ae",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc22218a"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "물폭탄 맞은 경북북부내륙에 최대 300㎜ 이상 더 내린다",
+                    "url": "http://www.kyongbuk.co.kr/news/articleView.html?idxno=2136960",
+                    "aid": "6cc1d4c8e102f508",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc22218b"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "[영상] 동빈대교 건설 공정률 28.5%…도심 교통허브·랜드마크 기대",
+                    "url": "http://www.kyongbuk.co.kr/news/articleView.html?idxno=2136969",
+                    "aid": "6cc1d4d19ad04ed1",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc22218c"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "[영상] 동빈대교 건설 공정률 28.5%…도심 교통허브·랜드마크 기대",
+                    "url": "http://www.kyongbuk.co.kr/news/articleView.html?idxno=2136969",
+                    "aid": "6cc1d4d19ad04ed1",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc22218d"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "[르포] 예천군 백석리 산사태 현장 가보니",
+                    "url": "http://www.kyongbuk.co.kr/news/articleView.html?idxno=2136951",
+                    "aid": "6cc1d4aa5294e8aa",
+                    "image": null,
+                    "_id": "64a374b9824d90d2cc4097ac"
+                }
+            ],
+            "pid": "54",
+            "name": "동아일보",
+            "logoLight": {
+                "url": "https://s.pstatic.net/static/newsstand/2020/logo/light/0604/337.png"
+            },
+            "logoDark": {
+                "url": "https://s.pstatic.net/static/newsstand/2020/logo/dark/0604/337.png"
+            },
+            "regDate": "20230717 05:37:59"
+        },
+        {
+            "materials": [
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "제주도, 노후 차집관로 2026년까지 전면 교체",
+                    "url": "http://www.jejudomin.co.kr/news/articleView.html?idxno=218066",
+                    "aid": "16dfd360b7561820",
+                    "image": {
+                        "url": "https://s.pstatic.net/dthumb.phinf/?src=%22https%3A%2F%2Fs.pstatic.net%2Fstatic%2Fnewsstand%2F2023%2F0717%2Farticle_img%2Fnew_main%2F9099%2F112920_001.jpg%22&type=nf312_208&service=navermain"
+                    },
+                    "_id": "643542ba1f0f6898fc221db4"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "제주도의회, 강경흠 의원 징계 착수…사퇴 요구 잇따라",
+                    "url": "http://www.jejudomin.co.kr/news/articleView.html?idxno=218046",
+                    "aid": "16dfd322e2f707e2",
+                    "image": null,
+                    "_id": "64af13a4548a597b72d3604a"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "제주도 ‘공공주도 2.0 풍력 조례’ 의회서 ‘제동’",
+                    "url": "http://www.jejudomin.co.kr/news/articleView.html?idxno=218022",
+                    "aid": "16dfd2e09f9208a0",
+                    "image": null,
+                    "_id": "64af13a4548a597b72d3604b"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "제주 자원순환사회 조성 핵심기반시설 본격 가동",
+                    "url": "http://www.jejudomin.co.kr/news/articleView.html?idxno=218057",
+                    "aid": "16dfd34228e80bc2",
+                    "image": null,
+                    "_id": "64b02a1363b70c6ebed54bff"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "양파·당근 과잉생산 우려...10% 이상 감축 필요",
+                    "url": "http://www.jejudomin.co.kr/news/articleView.html?idxno=218055",
+                    "aid": "16dfd34071651440",
+                    "image": null,
+                    "_id": "64b14b113c50cd9912fcde86"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "제주, 동물등록 8.7% 늘고↑...유기동물 11.8% 감소↓",
+                    "url": "http://www.jejudomin.co.kr/news/articleView.html?idxno=218054",
+                    "aid": "16dfd33f95a3987f",
+                    "image": null,
+                    "_id": "64b14b113c50cd9912fcde87"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "제주 마을관광 브랜드 ‘카름스테이’ 3곳 신규 선정",
+                    "url": "http://www.jejudomin.co.kr/news/articleView.html?idxno=218045",
+                    "aid": "16dfd32107358c21",
+                    "image": null,
+                    "_id": "64b284a8e82d6f14f22b4cc4"
+                }
+            ],
+            "pid": "55",
+            "name": "이데일리",
+            "logoLight": {
+                "url": "https://s.pstatic.net/static/newsstand/2020/logo/light/0604/389.png"
+            },
+            "logoDark": {
+                "url": "https://s.pstatic.net/static/newsstand/2020/logo/dark/0604/389.png"
+            },
+            "regDate": "20230717 11:20:37"
+        }
+    ],
+    "6": [
+        {
+            "materials": [
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "“음식 많이 담았다고 손님 쫓아낸 한식뷔페, 제가 한번 가봤습니다” (+리얼 후기)",
+                    "url": "https://www.wikitree.co.kr/articles/870491",
+                    "aid": "652a000743ea3699",
+                    "image": {
+                        "url": "https://s.pstatic.net/dthumb.phinf/?src=%22https%3A%2F%2Fs.pstatic.net%2Fstatic%2Fnewsstand%2F2023%2F0717%2Farticle_img%2Fnew_main%2F9157%2F113134_001.jpg%22&type=nf312_208&service=navermain"
+                    },
+                    "_id": "643542ba1f0f6898fc22208c"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "금수저 맞습니다...런닝맨 송지효 아버지 직업, '이 업체' 대표이사다",
+                    "url": "https://www.wikitree.co.kr/articles/870531",
+                    "aid": "652a030e3c84deb2",
+                    "image": null,
+                    "_id": "6496996b60f3c014e7a9bccd"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "'인천 아파트 칼부림' 흉기 찔린 30대 여성, 결국 사망… 가해자 정체가 밝혀졌다",
+                    "url": "https://www.wikitree.co.kr/articles/870528",
+                    "aid": "652a02f65b95258a",
+                    "image": null,
+                    "_id": "64a9659733520e07dac10f3b"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "이혼 후 게시물 모두 삭제…3년 만에 SNS 재개한 여배우, 근황 전했다",
+                    "url": "https://www.wikitree.co.kr/articles/870485",
+                    "aid": "6529ffecb59a97d4",
+                    "image": null,
+                    "_id": "64a9659733520e07dac10f3c"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "'오송 지하차도 침수' 희생자가 올린 페이스북 글... 마음이 찢어집니다",
+                    "url": "https://www.wikitree.co.kr/articles/870487",
+                    "aid": "6529ffee292fdb92",
+                    "image": null,
+                    "_id": "64b0dbfc548a597b72d3cdf3"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "'나는 자연인이다' 출연자, 경북 예천 산사태로 실종…아내는 숨진 채 발견",
+                    "url": "https://www.wikitree.co.kr/articles/870449",
+                    "aid": "6529ff74c6dc864c",
+                    "image": null,
+                    "_id": "64b0dbfc548a597b72d3cdf4"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "5월 결혼한 새신랑…'30살' 초등교사, 오송 지하차도 침수사고로 세상 떠났다",
+                    "url": "https://www.wikitree.co.kr/articles/870426",
+                    "aid": "6529ff332e88542d",
+                    "image": null,
+                    "_id": "64b0dbfc548a597b72d3cdf5"
+                }
+            ],
+            "pid": "56",
+            "name": "뉴시스",
+            "logoLight": {
+                "url": "https://s.pstatic.net/static/newsstand/2020/logo/light/0604/539.png"
+            },
+            "logoDark": {
+                "url": "https://s.pstatic.net/static/newsstand/2020/logo/dark/0604/539.png"
+            },
+            "regDate": "20230717 11:31:07"
+        },
+        {
+            "materials": [
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "'CJ 승계 핵심'은 올리브영?… 이재현의 큰 그림",
+                    "url": "https://www.moneys.co.kr/news/mwView.php?no=2023071414520662204&type=4&code=w0405&STAND=ST",
+                    "aid": "4274ad77e350c369",
+                    "image": {
+                        "url": "https://s.pstatic.net/dthumb.phinf/?src=%22https%3A%2F%2Fs.pstatic.net%2Fstatic%2Fnewsstand%2F2023%2F0717%2Farticle_img%2Fnew_main%2F9159%2F113134_001.jpg%22&type=nf312_208&service=navermain"
+                    },
+                    "_id": "643542ba1f0f6898fc222085"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "\"대출금리 올라\" 영끌족 비명… 주담대 금리 7% 육박",
+                    "url": "https://www.moneys.co.kr/news/mwView.php?no=2023071709462957121&type=4&code=w0202&STAND=SS",
+                    "aid": "2cf2ad96429f8f6a",
+                    "image": null,
+                    "_id": "64a0948c3e93486eac6c1932"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "'납품가 기싸움' 쿠팡, '햇반' 없어도 괜찮다?",
+                    "url": "https://www.moneys.co.kr/news/mwView.php?no=2023071708431989095&type=4&code=w0405&STAND=SS",
+                    "aid": "3a09765135e320cf",
+                    "image": null,
+                    "_id": "64aee3d4e82d6f14f22a6395"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "국제선 결항 아시아나, 비상대책 가동… 승객 피해 최소화",
+                    "url": "https://www.moneys.co.kr/news/mwView.php?no=2023071710195737812&type=4&code=w0406&STAND=SS",
+                    "aid": "0d3da8e06e1e4da0",
+                    "image": null,
+                    "_id": "64aee3d4e82d6f14f22a6396"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "韓 폭우 피해, 외신도 관심… \"동아시아 기후 위기 직면\"",
+                    "url": "https://www.moneys.co.kr/news/mwView.php?no=2023071709153565027&type=4&code=w1604&STAND=SS",
+                    "aid": "a791c706c35332fa",
+                    "image": null,
+                    "_id": "64b17417e9bedeca622c07f6"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "오송 지하차도 참사 현장서 웃은 공무원… \"소름 끼친다\"",
+                    "url": "https://www.moneys.co.kr/news/mwView.php?no=2023071709575642600&type=4&code=w1602&STAND=SS",
+                    "aid": "225ebaa3d87cf6fd",
+                    "image": null,
+                    "_id": "64b17417e9bedeca622c07f7"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "\"역시 불사조\"… 주윤발 건강이상설, '가짜뉴스'로 판명",
+                    "url": "https://www.moneys.co.kr/news/mwView.php?no=2023071708503414165&type=4&code=w1604&STAND=SS",
+                    "aid": "eb438184bf7625bc",
+                    "image": null,
+                    "_id": "64b17417e9bedeca622c07f8"
+                }
+            ],
+            "pid": "57",
+            "name": "한국경제",
+            "logoLight": {
+                "url": "https://s.pstatic.net/static/newsstand/2020/logo/light/0604/417.png"
+            },
+            "logoDark": {
+                "url": "https://s.pstatic.net/static/newsstand/2020/logo/dark/0604/417.png"
+            },
+            "regDate": "20230717 11:30:06"
+        },
+        {
+            "materials": [
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "'비 폭탄'으로 48명 사망·실종… \"오송 지하차도서 시신 3구 발견\"",
+                    "url": "https://www.newdaily.co.kr/site/data/html/2023/07/17/2023071700045.html",
+                    "aid": "7afc0839a02ac7f9",
+                    "image": {
+                        "url": "https://s.pstatic.net/dthumb.phinf/?src=%22https%3A%2F%2Fs.pstatic.net%2Fstatic%2Fnewsstand%2F2023%2F0717%2Farticle_img%2Fnew_main%2F9058%2F112248_001.jpg%22&type=nf312_208&service=navermain"
+                    },
+                    "_id": "643542ba1f0f6898fc22211f"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "尹 \"재난피해 지원 신속하게 해달라\"…폴란드서 호우대책 지시",
+                    "url": "https://www.newdaily.co.kr/site/data/html/2023/07/16/2023071600031.html",
+                    "aid": "c2bbe15c4b25ae5c",
+                    "image": null,
+                    "_id": "649d4ba160f3c014e7ab04c8"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "與 김기현, 폭우 피해에 귀국 일정 앞당겨… 5박7일 방미 마무리",
+                    "url": "https://www.newdaily.co.kr/site/data/html/2023/07/16/2023071600017.html",
+                    "aid": "632c7e94928e8514",
+                    "image": null,
+                    "_id": "649d4ba160f3c014e7ab04c9"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "국민의힘, '폭우 피해' 괴산 방문… \"특별재난지역 선포해야\"",
+                    "url": "https://www.newdaily.co.kr/site/data/html/2023/07/16/2023071600029.html",
+                    "aid": "9b7c6b137a4fa213",
+                    "image": null,
+                    "_id": "649ddffd7a6b147b6bf55df0"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "[N-포커스] 최저임금 벼랑끝 싸움… 尹 노동개혁 분수령",
+                    "url": "https://biz.newdaily.co.kr/site/data/html/2023/07/15/2023071500016.html",
+                    "aid": "fe220a51e498fdd1",
+                    "image": null,
+                    "_id": "64ada11f3c50cd9912fbe55c"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "다시 불붙은 수신경쟁… 대출금리 인상 부메랑",
+                    "url": "https://biz.newdaily.co.kr/site/data/html/2023/07/17/2023071700085.html",
+                    "aid": "67c5e2b969dd5579",
+                    "image": null,
+                    "_id": "64ada11f3c50cd9912fbe55d"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "삼바-롯바 인력 유출 갈등 고조…'불편한 동거' 속 상도 논란도",
+                    "url": "https://biz.newdaily.co.kr/site/data/html/2023/07/15/2023071500033.html",
+                    "aid": "62cff6f6241045b6",
+                    "image": null,
+                    "_id": "64ada11f3c50cd9912fbe55e"
+                }
+            ],
+            "pid": "58",
+            "name": "시사IN",
+            "logoLight": {
+                "url": "https://s.pstatic.net/static/newsstand/2020/logo/light/0604/327.png"
+            },
+            "logoDark": {
+                "url": "https://s.pstatic.net/static/newsstand/2020/logo/dark/0604/327.png"
+            },
+            "regDate": "20230717 11:20:10"
+        },
+        {
+            "materials": [
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "[여론조사]  인천시민 46.7% “유정복 시장 잘하고 있다”",
+                    "url": "https://www.incheonilbo.com/news/articleView.html?idxno=1203079",
+                    "aid": "284d86dd9e09acdd",
+                    "image": {
+                        "url": "https://s.pstatic.net/dthumb.phinf/?src=%22https%3A%2F%2Fs.pstatic.net%2Fstatic%2Fnewsstand%2F2023%2F0717%2Farticle_img%2Fnew_main%2F9097%2F112248_001.jpg%22&type=nf312_208&service=navermain"
+                    },
+                    "_id": "643542ba1f0f6898fc221d9f"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "[여론조사] 김동연 경기지사 지지율 급상승…“잘한다” 57.1%",
+                    "url": "https://www.incheonilbo.com/news/articleView.html?idxno=1203082",
+                    "aid": "284d86f5a13cbcb5",
+                    "image": null,
+                    "_id": "64aa5830d509cf07e8701c29"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "[여론조사] 인천시민·경기도민 윤석열 대통령 국정수행 평가",
+                    "url": "https://www.incheonilbo.com/news/articleView.html?idxno=1203075",
+                    "aid": "284d86d9d8c36ed9",
+                    "image": null,
+                    "_id": "64ab9b5df04b5ed2c5434f2b"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "[여론조사] 경기도민·인천시민 정당 지지도…민주당·국민의힘, 오차범위 내 '엎치락뒤치락'",
+                    "url": "https://www.incheonilbo.com/news/articleView.html?idxno=1203074",
+                    "aid": "284d86d8e771df58",
+                    "image": null,
+                    "_id": "64ab9b5df04b5ed2c5434f2c"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "[여론조사] 내년 총선, 인천시민은 변화 바란다",
+                    "url": "https://www.incheonilbo.com/news/articleView.html?idxno=1203077",
+                    "aid": "284d86dbbb668ddb",
+                    "image": null,
+                    "_id": "64ab9b5df04b5ed2c5434f2d"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "[여론조사] 내년 총선, 경기도민은 변화 바란다…지역 국회의원 '물갈이' 원해",
+                    "url": "https://www.incheonilbo.com/news/articleView.html?idxno=1203078",
+                    "aid": "284d86dcacb81d5c",
+                    "image": null,
+                    "_id": "64b3d1f51f0f6898fc3a224d"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "[창간 35주년 여론조사] 김동연 경기지사 지지율 급상승 이유…철도망 확충·민생경제 주 요인",
+                    "url": "https://www.incheonilbo.com/news/articleView.html?idxno=1203092",
+                    "aid": "284d87143daab914",
+                    "image": null,
+                    "_id": "64b3d1f51f0f6898fc3a224e"
+                }
+            ],
+            "pid": "59",
+            "name": "월간산",
+            "logoLight": {
+                "url": "https://s.pstatic.net/static/newsstand/up/2022/0331/nsd155937506.png"
+            },
+            "logoDark": {
+                "url": "https://s.pstatic.net/static/newsstand/up/2022/0331/nsd15594915.png"
+            },
+            "regDate": "20230717 11:20:04"
+        },
+        {
+            "materials": [
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "기록적 폭우에… 온 나라가 슬픔에 잠겼다",
+                    "url": "https://www.cctoday.co.kr/news/articleView.html?idxno=2181333",
+                    "aid": "99f490eae26eb2aa",
+                    "image": {
+                        "url": "https://s.pstatic.net/dthumb.phinf/?src=%22https%3A%2F%2Fs.pstatic.net%2Fstatic%2Fnewsstand%2F2023%2F0716%2Farticle_img%2Fnew_main%2F9063%2F183124_001.jpg%22&type=nf312_208&service=navermain"
+                    },
+                    "_id": "643542ba1f0f6898fc222149"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "충남 3곳·세종 국제화특구 지정 충청권 국제화 교육 기틀 마련 기대",
+                    "url": "https://www.cctoday.co.kr/news/articleView.html?idxno=2181137",
+                    "aid": "99f4896cb5f5b1ac",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc22214a"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "손 놓는 보건의료노조 충청지역 의료공백 불가피",
+                    "url": "https://www.cctoday.co.kr/news/articleView.html?idxno=2181057",
+                    "aid": "99f485e93c9549e9",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc22214b"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "‘지방시대위’ 세종서 출범 어디서나 살기 좋은 지방시대 구현",
+                    "url": "https://www.cctoday.co.kr/news/articleView.html?idxno=2180970",
+                    "aid": "99f4338a4c042c0a",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc22214c"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "“제발” 지하차도만 하염없이 바라보는 실종자 가족들",
+                    "url": "https://www.cctoday.co.kr/news/articleView.html?idxno=2181319",
+                    "aid": "99f490b2349888f2",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc22214d"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "집안까지 들이닥친 빗물 \"살림살이 둥둥 떠다녀\"",
+                    "url": "https://www.cctoday.co.kr/news/articleView.html?idxno=2181330",
+                    "aid": "99f490e74f2a3f67",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc22214e"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "여야 지도부, 폭우 피해 입은 충북 방문 복구 지원 약속",
+                    "url": "https://www.cctoday.co.kr/news/articleView.html?idxno=2181316",
+                    "aid": "99f490afa15415af",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc22214f"
+                }
+            ],
+            "pid": "60",
+            "name": "독서신문",
+            "logoLight": {
+                "url": "https://s.pstatic.net/static/newsstand/2020/logo/light/0604/331.png"
+            },
+            "logoDark": {
+                "url": "https://s.pstatic.net/static/newsstand/2020/logo/dark/0604/331.png"
+            },
+            "regDate": "20230716 18:27:01"
+        },
+        {
+            "materials": [
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "‘고리1’ 멈춘 지 6년…해체 시점도 불투명",
+                    "url": "http://www.kookje.co.kr/news2011/asp/newsbody.asp?code=0200&key=20230716.99099004808",
+                    "aid": "4cc1783739362c29",
+                    "image": {
+                        "url": "https://s.pstatic.net/dthumb.phinf/?src=%22https%3A%2F%2Fs.pstatic.net%2Fstatic%2Fnewsstand%2F2023%2F0717%2Farticle_img%2Fnew_main%2F9071%2F091151_001.jpg%22&type=nf312_208&service=navermain"
+                    },
+                    "_id": "643542ba1f0f6898fc222150"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "오송지하차도 참사 부산 초량 닮은꼴…홍수경보에도 교통통제 안해",
+                    "url": "http://www.kookje.co.kr/news2011/asp/newsbody.asp?code=0300&key=20230716.99001004885",
+                    "aid": "ef7612aca9dbac54",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc222151"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "윤 대통령 “우크라 평화연대 이니셔티브 추진”",
+                    "url": "http://www.kookje.co.kr/news2011/asp/newsbody.asp?code=0100&key=20230717.33001004863",
+                    "aid": "c54232ef23404df1",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc222152"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "“엑스포 유치 실패하더라도 가덕 신공항 건설을 그대로 추진”",
+                    "url": "http://www.kookje.co.kr/news2011/asp/newsbody.asp?code=0200&key=20230716.99099004797",
+                    "aid": "4cc1758cd0302734",
+                    "image": null,
+                    "_id": "64530bd61f0f6898fc278cb4"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "부산대병원 독자 파업 지속 “비정규직 직접고용 결단하라”",
+                    "url": "http://www.kookje.co.kr/news2011/asp/newsbody.asp?code=0300&key=20230717.22002004928",
+                    "aid": "529c5c5869e24368",
+                    "image": null,
+                    "_id": "64ad7df27a6b147b6bf89731"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "빅데이터 모으고, 골목여론 듣고…여야 총선모드 ‘ON’",
+                    "url": "http://www.kookje.co.kr/news2011/asp/newsbody.asp?code=0100&key=20230717.22005004711",
+                    "aid": "0facf7b5256d656b",
+                    "image": null,
+                    "_id": "64ad7df27a6b147b6bf89732"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "우주항공청법도, 보호출산제도…여야 대치에 법안 처리 ‘하세월’",
+                    "url": "http://www.kookje.co.kr/news2011/asp/newsbody.asp?code=0100&key=20230717.22005004785",
+                    "aid": "0facf892646734ee",
+                    "image": null,
+                    "_id": "64ad7df27a6b147b6bf89733"
+                }
+            ],
+            "pid": "61",
+            "name": "이코노타임즈",
+            "logoLight": {
+                "url": "https://s.pstatic.net/static/newsstand/2020/logo/light/0604/332.png"
+            },
+            "logoDark": {
+                "url": "https://s.pstatic.net/static/newsstand/2020/logo/dark/0604/332.png"
+            },
+            "regDate": "20230717 09:06:12"
+        },
+        {
+            "materials": [
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "'미우새' 이은지 \"택시기사父, 남친과 차 태워주며 12만원 받아\"",
+                    "url": "https://ent.sbs.co.kr/news/article.do?article_id=E10010273915&plink=STAND&cooper=NAVERMAIN",
+                    "aid": "26578a954cd4a94b",
+                    "image": {
+                        "url": "https://s.pstatic.net/dthumb.phinf/?src=%22https%3A%2F%2Fs.pstatic.net%2Fstatic%2Fnewsstand%2F2023%2F0717%2Farticle_img%2Fnew_main%2F9154%2F113134_001.jpg%22&type=nf312_208&service=navermain"
+                    },
+                    "_id": "643542ba1f0f6898fc22207e"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "신민아♥김우빈, 수해 이재민 위해 각 1억원 씩 기부",
+                    "url": "https://ent.sbs.co.kr/news/article.do?article_id=E10010273904&plink=STAND&cooper=NAVERMAIN",
+                    "aid": "10c216b506e3a56b",
+                    "image": null,
+                    "_id": "64a5b42158a9ce6eb3c6a2b9"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "'미션 임파서블7', 개봉 첫 주말 1위…누적 관객 176만 돌파",
+                    "url": "https://ent.sbs.co.kr/news/article.do?article_id=E10010273913&plink=STAND&cooper=NAVERMAIN",
+                    "aid": "24fe33579551b1c9",
+                    "image": null,
+                    "_id": "64b192c863b70c6ebed5aefd"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "'런닝맨' 송지효, \"부모님 통영서 여객선 사업中…부모님은 부모님, 나는 나\" 13년 만에 첫 고백",
+                    "url": "https://ent.sbs.co.kr/news/article.do?article_id=E10010273897&plink=STAND&cooper=NAVERMAIN",
+                    "aid": "46c6e3fc081469c4",
+                    "image": null,
+                    "_id": "64b4912f57629c14fd0b95dc"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "아이브 장원영, '여름 여신'의 독보적 청량미",
+                    "url": "https://ent.sbs.co.kr/news/article.do?article_id=E10010272499&plink=STAND&cooper=NAVERMAIN",
+                    "aid": "a9877fbd0a387d63",
+                    "image": null,
+                    "_id": "64b4912f57629c14fd0b95dd"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "'미션7', 역대 최고는 아니지만 시리즈의 정수를 담다",
+                    "url": "https://ent.sbs.co.kr/news/article.do?article_id=E10010273757&plink=STAND&cooper=NAVERMAIN",
+                    "aid": "6af383191196d147",
+                    "image": null,
+                    "_id": "64b4912f57629c14fd0b95de"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "돌아온 김선호 \"연기가 늘었으면 좋겠다\"",
+                    "url": "https://ent.sbs.co.kr/news/article.do?article_id=E10010273480&plink=STAND&cooper=NAVERMAIN",
+                    "aid": "0c646ae6649c9f5a",
+                    "image": null,
+                    "_id": "64b4912f57629c14fd0b95df"
+                }
+            ],
+            "pid": "62",
+            "name": "TJB대전방송",
+            "logoLight": {
+                "url": "https://s.pstatic.net/static/newsstand/up/2020/1228/nsd1681569.png"
+            },
+            "logoDark": {
+                "url": "https://s.pstatic.net/static/newsstand/up/2020/1228/nsd1688305.png"
+            },
+            "regDate": "20230717 11:31:07"
+        },
+        {
+            "materials": [
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "우주 ‘식집사’는 빛 대신 이산화탄소로 식물을 키운다?",
+                    "url": "https://www.sciencetimes.co.kr/?news=%ec%9a%b0%ec%a3%bc-%ec%8b%9d%ec%a7%91%ec%82%ac%eb%8a%94-%eb%b9%9b-%eb%8c%80%ec%8b%a0-%ec%9d%b4%ec%82%b0%ed%99%94%ed%83%84%ec%86%8c%eb%a1%9c-%ec%8b%9d%eb%ac%bc%ec%9d%84-%ed%82%a4",
+                    "aid": "bda852ce55333fb2",
+                    "image": {
+                        "url": "https://s.pstatic.net/dthumb.phinf/?src=%22https%3A%2F%2Fs.pstatic.net%2Fstatic%2Fnewsstand%2F2023%2F0717%2Farticle_img%2Fnew_main%2F9081%2F111451_001.jpg%22&type=nf312_208&service=navermain"
+                    },
+                    "_id": "643542ba1f0f6898fc221b5a"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "인종 장벽 없앤 인간 ‘판게놈 참조 지도’ 초안 나왔다",
+                    "url": "https://www.sciencetimes.co.kr/?news=%ec%9d%b8%ec%a2%85-%ec%9e%a5%eb%b2%bd-%ec%97%86%ec%95%a4-%ec%9d%b8%ea%b0%84-%ed%8c%90%ea%b2%8c%eb%86%88-%ec%b0%b8%ec%a1%b0-%ec%a7%80%eb%8f%84-%ec%b4%88%ec%95%88-%eb%82%98%ec%99%94",
+                    "aid": "37625c79b7d50867",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc221b5b"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "‘모나리자’의 눈썹, 짙고 두꺼웠을 수도 있다?",
+                    "url": "https://www.sciencetimes.co.kr/?news=%eb%aa%a8%eb%82%98%eb%a6%ac%ec%9e%90%ec%9d%98-%eb%88%88%ec%8d%b9-%ec%a7%99%ea%b3%a0-%eb%91%90%ea%ba%bc%ec%9b%a0%ec%9d%84-%ec%88%98%eb%8f%84-%ec%9e%88%eb%8b%a4",
+                    "aid": "03b0b4d7a107bdd7",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc221b5c"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "제1회 세계 한인 과학기술인 대회 마지막날, 다양한 기조강연과 포럼이 진행되다",
+                    "url": "https://www.sciencetimes.co.kr/?news=%ec%a0%9c1%ed%9a%8c-%ec%84%b8%ea%b3%84-%ed%95%9c%ec%9d%b8-%ea%b3%bc%ed%95%99%ea%b8%b0%ec%88%a0%ec%9d%b8-%eb%8c%80%ed%9a%8c-%eb%a7%88%ec%a7%80%eb%a7%89%eb%82%a0-%eb%8b%a4%ec%96%91%ed%95%9c-%ea%b8%b0",
+                    "aid": "d31ce9d4f683c76c",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc221b5d"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "디지털 헬스케어, 바이오경제 2.0의 핵심으로 도약하나",
+                    "url": "https://www.sciencetimes.co.kr/?news=%eb%94%94%ec%a7%80%ed%84%b8-%ed%97%ac%ec%8a%a4%ec%bc%80%ec%96%b4-%eb%b0%94%ec%9d%b4%ec%98%a4%ea%b2%bd%ec%a0%9c-2-0%ec%9d%98-%ed%95%b5%ec%8b%ac%ec%9c%bc%eb%a1%9c-%eb%8f%84%ec%95%bd%ed%95%98%eb%82%98",
+                    "aid": "6b7c1fd04d7e58b0",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc221b5e"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "“림프관만 20년 넘게 연구한 덕에 150년의 난제 풀었죠”",
+                    "url": "https://www.sciencetimes.co.kr/?p=252189",
+                    "aid": "38b34093f68134cd",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc221b5f"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "로봇 요리사의 ‘특별한 요리 비결’은 유튜브?",
+                    "url": "https://www.sciencetimes.co.kr/?p=252189",
+                    "aid": "38b34093f68134cd",
+                    "image": null,
+                    "_id": "643542ba1f0f6898fc221b60"
+                }
+            ],
+            "pid": "63",
+            "name": "시사오늘 시사IN",
+            "logoLight": {
+                "url": "https://s.pstatic.net/static/newsstand/2020/logo/light/0604/355.png"
+            },
+            "logoDark": {
+                "url": "https://s.pstatic.net/static/newsstand/2020/logo/dark/0604/355.png"
+            },
+            "regDate": "20230714 10:41:16"
+        },
+        {
+            "materials": [
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "“아무리 싸도 억” 송지효 부모님 통영 여객선 사업 큰 손이었다(런닝맨)[어제TV]",
+                    "url": "http://news.newsen.com/news_view.php?uid=202307161856566710",
+                    "aid": "955ae1a0debf2520",
+                    "image": {
+                        "url": "https://s.pstatic.net/dthumb.phinf/?src=%22https%3A%2F%2Fs.pstatic.net%2Fstatic%2Fnewsstand%2F2023%2F0717%2Farticle_img%2Fnew_main%2F9126%2F085139_001.jpg%22&type=nf312_208&service=navermain"
+                    },
+                    "_id": "643542ba1f0f6898fc222111"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "김우빈→이찬원 폭우 피해에 ★ 기부 행렬 “도움 되기를” [종합]",
+                    "url": "http://news.newsen.com/news_view.php?uid=202307161637415710",
+                    "aid": "cffa229e4be4541e",
+                    "image": null,
+                    "_id": "64382002d2afac98f57ccef6"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "빅히트 뮤직 측 “BTS 정국 유튜브 집계 문제없다”[공식]",
+                    "url": "http://news.newsen.com/news_view.php?uid=202307170753070410",
+                    "aid": "fa821967f7653567",
+                    "image": null,
+                    "_id": "645661636e592107d2d4489a"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "강동원, 정용진 부회장 쌍둥이 남매 만나 깜짝 사인회 ‘삼촌미소’",
+                    "url": "http://news.newsen.com/news_view.php?uid=202307170702342410",
+                    "aid": "c32b29e3313554e3",
+                    "image": null,
+                    "_id": "646563463e93486eac614c31"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "“열심히 드럼 칠게요” 데이식스 도운, 성진·영케이 축하 속 만기 전역[종합]",
+                    "url": "http://news.newsen.com/news_view.php?uid=202307162034360410",
+                    "aid": "aa8593bc17e2a6fc",
+                    "image": null,
+                    "_id": "646563463e93486eac614c32"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "백진희 딸 낳았다, 안재현과 1년만 운명적 재회 (진짜가)[어제TV]",
+                    "url": "http://news.newsen.com/news_view.php?uid=202307170600231710",
+                    "aid": "c356eb24702c63a4",
+                    "image": null,
+                    "_id": "646563463e93486eac614c33"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "여자아이들 미연 ‘옅은 화장에도 예쁨 폭발’[포토엔HD]",
+                    "url": "http://news.newsen.com/news_view.php?uid=202307161853393510",
+                    "aid": "f36760832c1cb243",
+                    "image": null,
+                    "_id": "646563463e93486eac614c34"
+                }
+            ],
+            "pid": "64",
+            "name": "데일리한국",
+            "logoLight": {
+                "url": "https://s.pstatic.net/static/newsstand/2020/logo/light/0604/447.png"
+            },
+            "logoDark": {
+                "url": "https://s.pstatic.net/static/newsstand/2020/logo/dark/0604/447.png"
+            },
+            "regDate": "20230717 08:45:34"
+        },
+        {
+            "materials": [
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "<마당이 있는 집> 원작자 김진영 인터뷰",
+                    "url": "https://ch.yes24.com/Article/View/54599?y_contents=채널예스&y_channel=뉴스캐스트&y_area=61",
+                    "aid": "7737d4728b170632",
+                    "image": {
+                        "url": "https://s.pstatic.net/dthumb.phinf/?src=%22https%3A%2F%2Fs.pstatic.net%2Fstatic%2Fnewsstand%2F2023%2F0717%2Farticle_img%2Fnew_main%2F9084%2F113512_001.jpg%22&type=nf312_208&service=navermain"
+                    },
+                    "_id": "643542ba1f0f6898fc221ba7"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "What's in my cart? 책 장바구니 특집!",
+                    "url": "https://ch.yes24.com/Article/View/54595?y_contents=채널예스&y_channel=뉴스캐스트&y_area=61",
+                    "aid": "e232196e2093fc2e",
+                    "image": null,
+                    "_id": "648049361f0f6898fc301cae"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "삶이 우울하거나 지겨우면 이 작품을 보라!",
+                    "url": "https://ch.yes24.com/Article/View/54591?y_contents=채널예스&y_channel=뉴스캐스트&y_area=61",
+                    "aid": "4d2c5e6ab610f22a",
+                    "image": null,
+                    "_id": "64b4a4a660f3c014e7afd1a6"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "뮤지컬 <신의 손가락> - 모두의 인생은 한 편의 동화다",
+                    "url": "https://ch.yes24.com/Article/View/54583?y_contents=채널예스&y_channel=뉴스캐스트&y_area=61",
+                    "aid": "54c2d28d28660dcd",
+                    "image": null,
+                    "_id": "64b4a4a660f3c014e7afd1a7"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "색채를 찾아 떠나는 프로방스 여행",
+                    "url": "https://ch.yes24.com/Article/View/54603?y_contents=채널예스&y_channel=뉴스캐스트&y_area=61",
+                    "aid": "d8004a16f6443196",
+                    "image": null,
+                    "_id": "64b4a4a660f3c014e7afd1a8"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "[김소미의 혼자 영화관에 갔어] 외로운 방조자들의 우주 - <스파이더맨 : 어크로스 더 유니버스>",
+                    "url": "https://ch.yes24.com/Article/View/54602?y_contents=채널예스&y_channel=뉴스캐스트&y_area=61",
+                    "aid": "f2bedb555ba36f15",
+                    "image": null,
+                    "_id": "64b4a4a660f3c014e7afd1a9"
+                },
+                {
+                    "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                    "gdid": null,
+                    "title": "[임진아의 카페 생활] 여름 방학 기분 - 커먼마치",
+                    "url": "https://ch.yes24.com/Article/View/54600?y_contents=채널예스&y_channel=뉴스캐스트&y_area=61",
+                    "aid": "283bfdd32661ea13",
+                    "image": null,
+                    "_id": "64b4a4a660f3c014e7afd1aa"
+                }
+            ],
+            "pid": "65",
+            "name": "뉴스토마토",
+            "logoLight": {
+                "url": "https://s.pstatic.net/static/newsstand/up/2023/0418/nsd124959421.png"
+            },
+            "logoDark": {
+                "url": "https://s.pstatic.net/static/newsstand/up/2023/0418/nsd124945796.png"
+            },
+            "regDate": "20230717 11:30:46"
+        }
+    ]
+}

--- a/listView.json
+++ b/listView.json
@@ -71,10 +71,10 @@
             "pid": "1",
             "name": "머니투데이",
             "logoLight": {
-                "url": "https://s.pstatic.net/static/newsstand/2020/logo/light/0604/301.png"
+                "url": "./assets/newspaper/Light/1.png"
             },
             "logoDark": {
-                "url": "https://s.pstatic.net/static/newsstand/2020/logo/dark/0604/301.png"
+                "url": "./assets/newspaper/Dark/1.png"
             },
             "regDate": "20230717 11:10:36"
         },
@@ -149,10 +149,10 @@
             "pid": "2",
             "name": "경향신문",
             "logoLight": {
-                "url": "https://s.pstatic.net/static/newsstand/2020/logo/light/0604/364.png"
+                "url": "./assets/newspaper/Light/2.png"
             },
             "logoDark": {
-                "url": "https://s.pstatic.net/static/newsstand/2020/logo/dark/0604/364.png"
+                "url": "./assets/newspaper/Dark/2.png"
             },
             "regDate": "20230713 09:58:00"
         },
@@ -227,10 +227,10 @@
             "pid": "3",
             "name": "뉴스타파",
             "logoLight": {
-                "url": "https://s.pstatic.net/static/newsstand/2020/logo/light/0604/447.png"
+                "url": "./assets/newspaper/Light/3.png"
             },
             "logoDark": {
-                "url": "https://s.pstatic.net/static/newsstand/2020/logo/dark/0604/447.png"
+                "url": "./assets/newspaper/Dark/3.png"
             },
             "regDate": "20230717 08:45:34"
         },
@@ -305,10 +305,10 @@
             "pid": "4",
             "name": "오마이뉴스",
             "logoLight": {
-                "url": "https://s.pstatic.net/static/newsstand/2020/logo/light/0604/340.png"
+                "url": "./assets/newspaper/Light/4.png"
             },
             "logoDark": {
-                "url": "https://s.pstatic.net/static/newsstand/2020/logo/dark/0604/340.png"
+                "url": "./assets/newspaper/Dark/4.png"
             },
             "regDate": "20230717 10:37:44"
         },
@@ -383,10 +383,10 @@
             "pid": "5",
             "name": "데일리안",
             "logoLight": {
-                "url": "https://s.pstatic.net/static/newsstand/2020/logo/light/0604/364.png"
+                "url": "./assets/newspaper/Light/5.png"
             },
             "logoDark": {
-                "url": "https://s.pstatic.net/static/newsstand/2020/logo/dark/0604/364.png"
+                "url": "./assets/newspaper/Dark/5.png"
             },
             "regDate": "20230713 09:58:00"
         },
@@ -461,10 +461,10 @@
             "pid": "6",
             "name": "스포츠서울",
             "logoLight": {
-                "url": "https://s.pstatic.net/static/newsstand/2020/logo/light/0604/331.png"
+                "url": "./assets/newspaper/Light/6.png"
             },
             "logoDark": {
-                "url": "https://s.pstatic.net/static/newsstand/2020/logo/dark/0604/331.png"
+                "url": "./assets/newspaper/Dark/6.png"
             },
             "regDate": "20230716 18:27:01"
         },
@@ -539,10 +539,10 @@
             "pid": "7",
             "name": "스포츠동아",
             "logoLight": {
-                "url": "https://s.pstatic.net/static/newsstand/2020/logo/light/0604/333.png"
+                "url": "./assets/newspaper/Light/7.png"
             },
             "logoDark": {
-                "url": "https://s.pstatic.net/static/newsstand/2020/logo/dark/0604/333.png"
+                "url": "./assets/newspaper/Dark/7.png"
             },
             "regDate": "20230717 11:01:04"
         },
@@ -617,10 +617,10 @@
             "pid": "8",
             "name": "문화일보",
             "logoLight": {
-                "url": "https://s.pstatic.net/static/newsstand/2020/logo/light/0604/396.png"
+                "url": "./assets/newspaper/Light/8.png"
             },
             "logoDark": {
-                "url": "https://s.pstatic.net/static/newsstand/2020/logo/dark/0604/396.png"
+                "url": "./assets/newspaper/Dark/8.png"
             },
             "regDate": "20230717 10:27:57"
         },
@@ -695,10 +695,10 @@
             "pid": "9",
             "name": "KBS World",
             "logoLight": {
-                "url": "https://s.pstatic.net/static/newsstand/up/2020/0803/nsd20247547.png"
+                "url": "./assets/newspaper/Light/9.png"
             },
             "logoDark": {
-                "url": "https://s.pstatic.net/static/newsstand/up/2020/0803/nsd202358800.png"
+                "url": "./assets/newspaper/Dark/9.png"
             },
             "regDate": "20230717 10:35:16"
         }
@@ -775,10 +775,10 @@
             "pid": "10",
             "name": "한국중앙데일리",
             "logoLight": {
-                "url": "https://s.pstatic.net/static/newsstand/2020/logo/light/0604/310.png"
+                "url": "./assets/newspaper/Light/10.png"
             },
             "logoDark": {
-                "url": "https://s.pstatic.net/static/newsstand/2020/logo/dark/0604/310.png"
+                "url": "./assets/newspaper/Dark/10.png"
             },
             "regDate": "20230717 11:10:03"
         },
@@ -853,10 +853,10 @@
             "pid": "11",
             "name": "인사이트",
             "logoLight": {
-                "url": "https://s.pstatic.net/static/newsstand/2020/logo/light/0604/334.png"
+                "url": "./assets/newspaper/Light/11.png"
             },
             "logoDark": {
-                "url": "https://s.pstatic.net/static/newsstand/2020/logo/dark/0604/334.png"
+                "url": "./assets/newspaper/Dark/11.png"
             },
             "regDate": "20230717 10:33:59"
         },
@@ -931,10 +931,10 @@
             "pid": "12",
             "name": "법률방송뉴스",
             "logoLight": {
-                "url": "https://s.pstatic.net/static/newsstand/up/2023/0418/nsd124959421.png"
+                "url": "./assets/newspaper/Light/12.png"
             },
             "logoDark": {
-                "url": "https://s.pstatic.net/static/newsstand/up/2023/0418/nsd124945796.png"
+                "url": "./assets/newspaper/Dark/12.png"
             },
             "regDate": "20230717 11:10:46"
         },
@@ -1009,10 +1009,10 @@
             "pid": "13",
             "name": "시사저널",
             "logoLight": {
-                "url": "https://s.pstatic.net/static/newsstand/2020/logo/light/0604/326.png"
+                "url": "./assets/newspaper/Light/13.png"
             },
             "logoDark": {
-                "url": "https://s.pstatic.net/static/newsstand/2020/logo/dark/0604/326.png"
+                "url": "./assets/newspaper/Dark/13.png"
             },
             "regDate": "20230717 10:53:42"
         },
@@ -1087,10 +1087,10 @@
             "pid": "14",
             "name": "조이뉴스",
             "logoLight": {
-                "url": "https://s.pstatic.net/static/newsstand/2020/logo/light/0604/326.png"
+                "url": "./assets/newspaper/Light/14.png"
             },
             "logoDark": {
-                "url": "https://s.pstatic.net/static/newsstand/2020/logo/dark/0604/326.png"
+                "url": "./assets/newspaper/Dark/14.png"
             },
             "regDate": "20230717 10:53:42"
         },
@@ -1165,10 +1165,10 @@
             "pid": "15",
             "name": "헤럴드경제",
             "logoLight": {
-                "url": "https://s.pstatic.net/static/newsstand/2020/logo/light/0604/389.png"
+                "url": "./assets/newspaper/Light/15.png"
             },
             "logoDark": {
-                "url": "https://s.pstatic.net/static/newsstand/2020/logo/dark/0604/389.png"
+                "url": "./assets/newspaper/Dark/15.png"
             },
             "regDate": "20230717 11:10:38"
         },
@@ -1243,10 +1243,10 @@
             "pid": "16",
             "name": "에너지경제",
             "logoLight": {
-                "url": "https://s.pstatic.net/static/newsstand/up/2023/0418/nsd124959421.png"
+                "url": "./assets/newspaper/Light/16.png"
             },
             "logoDark": {
-                "url": "https://s.pstatic.net/static/newsstand/up/2023/0418/nsd124945796.png"
+                "url": "./assets/newspaper/Dark/16.png"
             },
             "regDate": "20230717 11:10:46"
         }
@@ -1323,10 +1323,10 @@
             "pid": "17",
             "name": "비즈니스포스트",
             "logoLight": {
-                "url": "https://s.pstatic.net/static/newsstand/2020/logo/light/0604/354.png"
+                "url": "./assets/newspaper/Light/17.png"
             },
             "logoDark": {
-                "url": "https://s.pstatic.net/static/newsstand/2020/logo/dark/0604/354.png"
+                "url": "./assets/newspaper/Dark/17.png"
             },
             "regDate": "20230717 10:00:00"
         },
@@ -1401,10 +1401,10 @@
             "pid": "18",
             "name": "스코어데일리",
             "logoLight": {
-                "url": "https://s.pstatic.net/static/newsstand/up/2021/1130/nsd10159718.png"
+                "url": "./assets/newspaper/Light/18.png"
             },
             "logoDark": {
-                "url": "https://s.pstatic.net/static/newsstand/up/2021/1130/nsd101536636.png"
+                "url": "./assets/newspaper/Dark/18.png"
             },
             "regDate": "20230717 11:10:10"
         },
@@ -1479,10 +1479,10 @@
             "pid": "19",
             "name": "KNN",
             "logoLight": {
-                "url": "https://s.pstatic.net/static/newsstand/2020/logo/light/0604/334.png"
+                "url": "./assets/newspaper/Light/19.png"
             },
             "logoDark": {
-                "url": "https://s.pstatic.net/static/newsstand/2020/logo/dark/0604/334.png"
+                "url": "./assets/newspaper/Dark/19.png"
             },
             "regDate": "20230717 10:33:59"
         },
@@ -1557,10 +1557,10 @@
             "pid": "20",
             "name": "한국헤럴드",
             "logoLight": {
-                "url": "https://s.pstatic.net/static/newsstand/2020/logo/light/0604/364.png"
+                "url": "./assets/newspaper/Light/20.png"
             },
             "logoDark": {
-                "url": "https://s.pstatic.net/static/newsstand/2020/logo/dark/0604/364.png"
+                "url": "./assets/newspaper/Dark/20.png"
             },
             "regDate": "20230713 09:58:00"
         },
@@ -1635,10 +1635,10 @@
             "pid": "21",
             "name": "MBC",
             "logoLight": {
-                "url": "https://s.pstatic.net/static/newsstand/2020/logo/light/0604/536.png"
+                "url": "./assets/newspaper/Light/21.png"
             },
             "logoDark": {
-                "url": "https://s.pstatic.net/static/newsstand/2020/logo/dark/0604/536.png"
+                "url": "./assets/newspaper/Dark/21.png"
             },
             "regDate": "20230717 11:06:35"
         },
@@ -1713,10 +1713,10 @@
             "pid": "22",
             "name": "뉴데일리",
             "logoLight": {
-                "url": "https://s.pstatic.net/static/newsstand/2020/logo/light/0604/368.png"
+                "url": "./assets/newspaper/Light/22.png"
             },
             "logoDark": {
-                "url": "https://s.pstatic.net/static/newsstand/2020/logo/dark/0604/368.png"
+                "url": "./assets/newspaper/Dark/22.png"
             },
             "regDate": "20230717 11:08:52"
         },
@@ -1791,10 +1791,10 @@
             "pid": "23",
             "name": "국민일보",
             "logoLight": {
-                "url": "https://s.pstatic.net/static/newsstand/2020/logo/light/0604/336.png"
+                "url": "./assets/newspaper/Light/23.png"
             },
             "logoDark": {
-                "url": "https://s.pstatic.net/static/newsstand/2020/logo/dark/0604/336.png"
+                "url": "./assets/newspaper/Dark/23.png"
             },
             "regDate": "20230717 09:34:24"
         },
@@ -1869,10 +1869,10 @@
             "pid": "24",
             "name": "일간스포츠",
             "logoLight": {
-                "url": "https://s.pstatic.net/static/newsstand/up/2022/0331/nsd155937506.png"
+                "url": "./assets/newspaper/Light/24.png"
             },
             "logoDark": {
-                "url": "https://s.pstatic.net/static/newsstand/up/2022/0331/nsd15594915.png"
+                "url": "./assets/newspaper/Dark/24.png"
             },
             "regDate": "20230717 11:20:04"
         },
@@ -1947,10 +1947,10 @@
             "pid": "25",
             "name": "ZDNET Korea",
             "logoLight": {
-                "url": "https://s.pstatic.net/static/newsstand/2020/logo/light/0604/417.png"
+                "url": "./assets/newspaper/Light/25.png"
             },
             "logoDark": {
-                "url": "https://s.pstatic.net/static/newsstand/2020/logo/dark/0604/417.png"
+                "url": "./assets/newspaper/Dark/25.png"
             },
             "regDate": "20230717 11:10:05"
         }
@@ -2027,10 +2027,10 @@
             "pid": "26",
             "name": "마이데일리",
             "logoLight": {
-                "url": "https://s.pstatic.net/static/newsstand/2020/logo/light/0604/356.png"
+                "url": "./assets/newspaper/Light/26.png"
             },
             "logoDark": {
-                "url": "https://s.pstatic.net/static/newsstand/2020/logo/dark/0604/356.png"
+                "url": "./assets/newspaper/Dark/26.png"
             },
             "regDate": "20230717 10:59:06"
         },
@@ -2105,10 +2105,10 @@
             "pid": "27",
             "name": "SBS",
             "logoLight": {
-                "url": "https://s.pstatic.net/static/newsstand/2020/logo/light/0604/389.png"
+                "url": "./assets/newspaper/Light/27.png"
             },
             "logoDark": {
-                "url": "https://s.pstatic.net/static/newsstand/2020/logo/dark/0604/389.png"
+                "url": "./assets/newspaper/Dark/27.png"
             },
             "regDate": "20230717 11:10:38"
         },
@@ -2183,10 +2183,10 @@
             "pid": "28",
             "name": "서울경제",
             "logoLight": {
-                "url": "https://s.pstatic.net/static/newsstand/2020/logo/light/0604/422.png"
+                "url": "./assets/newspaper/Light/28.png"
             },
             "logoDark": {
-                "url": "https://s.pstatic.net/static/newsstand/2020/logo/dark/0604/422.png"
+                "url": "./assets/newspaper/Dark/28.png"
             },
             "regDate": "20230717 11:22:16"
         },
@@ -2261,10 +2261,10 @@
             "pid": "29",
             "name": "매일경제",
             "logoLight": {
-                "url": "https://s.pstatic.net/static/newsstand/2020/logo/light/0604/440.png"
+                "url": "./assets/newspaper/Light/29.png"
             },
             "logoDark": {
-                "url": "https://s.pstatic.net/static/newsstand/2020/logo/dark/0604/440.png"
+                "url": "./assets/newspaper/Dark/29.png"
             },
             "regDate": "20230717 11:20:02"
         },
@@ -2339,10 +2339,10 @@
             "pid": "30",
             "name": "MBN",
             "logoLight": {
-                "url": "https://s.pstatic.net/static/newsstand/2020/logo/light/0604/396.png"
+                "url": "./assets/newspaper/Light/30.png"
             },
             "logoDark": {
-                "url": "https://s.pstatic.net/static/newsstand/2020/logo/dark/0604/396.png"
+                "url": "./assets/newspaper/Dark/30.png"
             },
             "regDate": "20230717 11:20:31"
         },
@@ -2417,10 +2417,10 @@
             "pid": "31",
             "name": "YTN",
             "logoLight": {
-                "url": "https://s.pstatic.net/static/newsstand/up/2020/0803/nsd20247547.png"
+                "url": "./assets/newspaper/Light/31.png"
             },
             "logoDark": {
-                "url": "https://s.pstatic.net/static/newsstand/up/2020/0803/nsd202358800.png"
+                "url": "./assets/newspaper/Dark/31.png"
             },
             "regDate": "20230717 10:35:16"
         },
@@ -2495,10 +2495,10 @@
             "pid": "32",
             "name": "시사위크",
             "logoLight": {
-                "url": "https://s.pstatic.net/static/newsstand/2020/logo/light/0604/356.png"
+                "url": "./assets/newspaper/Light/32.png"
             },
             "logoDark": {
-                "url": "https://s.pstatic.net/static/newsstand/2020/logo/dark/0604/356.png"
+                "url": "./assets/newspaper/Dark/32.png"
             },
             "regDate": "20230717 10:59:06"
         },
@@ -2573,10 +2573,10 @@
             "pid": "33",
             "name": "세계일보",
             "logoLight": {
-                "url": "https://s.pstatic.net/static/newsstand/2020/logo/light/0604/353.png"
+                "url": "./assets/newspaper/Light/33.png"
             },
             "logoDark": {
-                "url": "https://s.pstatic.net/static/newsstand/2020/logo/dark/0604/353.png"
+                "url": "./assets/newspaper/Dark/33.png"
             },
             "regDate": "20230715 06:51:19"
         },
@@ -2651,10 +2651,10 @@
             "pid": "34",
             "name": "디지털투데이",
             "logoLight": {
-                "url": "https://s.pstatic.net/static/newsstand/2020/logo/light/0604/330.png"
+                "url": "./assets/newspaper/Light/34.png"
             },
             "logoDark": {
-                "url": "https://s.pstatic.net/static/newsstand/2020/logo/dark/0604/330.png"
+                "url": "./assets/newspaper/Dark/34.png"
             },
             "regDate": "20230717 10:43:52"
         },
@@ -2729,10 +2729,10 @@
             "pid": "35",
             "name": "데이터뉴스",
             "logoLight": {
-                "url": "https://s.pstatic.net/static/newsstand/2020/logo/light/0604/353.png"
+                "url": "./assets/newspaper/Light/35.png"
             },
             "logoDark": {
-                "url": "https://s.pstatic.net/static/newsstand/2020/logo/dark/0604/353.png"
+                "url": "./assets/newspaper/Dark/35.png"
             },
             "regDate": "20230715 06:51:19"
         }
@@ -2809,10 +2809,10 @@
             "pid": "36",
             "name": "한국대학신문",
             "logoLight": {
-                "url": "https://s.pstatic.net/static/newsstand/2020/logo/light/0604/333.png"
+                "url": "./assets/newspaper/Light/36.png"
             },
             "logoDark": {
-                "url": "https://s.pstatic.net/static/newsstand/2020/logo/dark/0604/333.png"
+                "url": "./assets/newspaper/Dark/36.png"
             },
             "regDate": "20230717 11:01:04"
         },
@@ -2887,10 +2887,10 @@
             "pid": "37",
             "name": "서울파이낸스",
             "logoLight": {
-                "url": "https://s.pstatic.net/static/newsstand/2020/logo/light/0604/338.png"
+                "url": "./assets/newspaper/Light/37.png"
             },
             "logoDark": {
-                "url": "https://s.pstatic.net/static/newsstand/2020/logo/dark/0604/338.png"
+                "url": "./assets/newspaper/Dark/37.png"
             },
             "regDate": "20230716 21:36:43"
         },
@@ -2965,10 +2965,10 @@
             "pid": "38",
             "name": "엑스포스뉴스",
             "logoLight": {
-                "url": "https://s.pstatic.net/static/newsstand/2020/logo/light/0604/539.png"
+                "url": "./assets/newspaper/Light/38.png"
             },
             "logoDark": {
-                "url": "https://s.pstatic.net/static/newsstand/2020/logo/dark/0604/539.png"
+                "url": "./assets/newspaper/Dark/38.png"
             },
             "regDate": "20230717 11:22:20"
         },
@@ -3043,10 +3043,10 @@
             "pid": "39",
             "name": "맥스무비",
             "logoLight": {
-                "url": "https://s.pstatic.net/static/newsstand/2020/logo/light/0604/312.png"
+                "url": "./assets/newspaper/Light/39.png"
             },
             "logoDark": {
-                "url": "https://s.pstatic.net/static/newsstand/2020/logo/dark/0604/312.png"
+                "url": "./assets/newspaper/Dark/39.png"
             },
             "regDate": "20230717 08:56:59"
         },
@@ -3121,10 +3121,10 @@
             "pid": "40",
             "name": "OBS",
             "logoLight": {
-                "url": "https://s.pstatic.net/static/newsstand/2020/logo/light/0604/389.png"
+                "url": "./assets/newspaper/Light/40.png"
             },
             "logoDark": {
-                "url": "https://s.pstatic.net/static/newsstand/2020/logo/dark/0604/389.png"
+                "url": "./assets/newspaper/Dark/40.png"
             },
             "regDate": "20230717 11:20:37"
         },
@@ -3199,10 +3199,10 @@
             "pid": "41",
             "name": "소년한국일보",
             "logoLight": {
-                "url": "https://s.pstatic.net/static/newsstand/2020/logo/light/0604/345.png"
+                "url": "./assets/newspaper/Light/41.png"
             },
             "logoDark": {
-                "url": "https://s.pstatic.net/static/newsstand/2020/logo/dark/0604/345.png"
+                "url": "./assets/newspaper/Dark/41.png"
             },
             "regDate": "20230716 18:27:27"
         },
@@ -3277,10 +3277,10 @@
             "pid": "42",
             "name": "한국일보",
             "logoLight": {
-                "url": "https://s.pstatic.net/static/newsstand/2020/logo/light/0604/340.png"
+                "url": "./assets/newspaper/Light/42.png"
             },
             "logoDark": {
-                "url": "https://s.pstatic.net/static/newsstand/2020/logo/dark/0604/340.png"
+                "url": "./assets/newspaper/Dark/42.png"
             },
             "regDate": "20230717 10:37:44"
         },
@@ -3355,10 +3355,10 @@
             "pid": "43",
             "name": "Sportal korea",
             "logoLight": {
-                "url": "https://s.pstatic.net/static/newsstand/2020/logo/light/0604/338.png"
+                "url": "./assets/newspaper/Light/43.png"
             },
             "logoDark": {
-                "url": "https://s.pstatic.net/static/newsstand/2020/logo/dark/0604/338.png"
+                "url": "./assets/newspaper/Dark/43.png"
             },
             "regDate": "20230716 21:36:43"
         },
@@ -3433,10 +3433,10 @@
             "pid": "44",
             "name": "아시아경제",
             "logoLight": {
-                "url": "https://s.pstatic.net/static/newsstand/2020/logo/light/0604/312.png"
+                "url": "./assets/newspaper/Light/44.png"
             },
             "logoDark": {
-                "url": "https://s.pstatic.net/static/newsstand/2020/logo/dark/0604/312.png"
+                "url": "./assets/newspaper/Dark/44.png"
             },
             "regDate": "20230717 08:56:59"
         },
@@ -3511,10 +3511,10 @@
             "pid": "45",
             "name": "프레시안",
             "logoLight": {
-                "url": "https://s.pstatic.net/static/newsstand/2020/logo/light/0604/363.png"
+                "url": "./assets/newspaper/Light/45.png"
             },
             "logoDark": {
-                "url": "https://s.pstatic.net/static/newsstand/2020/logo/dark/0604/363.png"
+                "url": "./assets/newspaper/Dark/45.png"
             },
             "regDate": "20230717 09:06:20"
         },
@@ -3589,10 +3589,10 @@
             "pid": "46",
             "name": "노컷뉴스",
             "logoLight": {
-                "url": "https://s.pstatic.net/static/newsstand/2020/logo/light/0604/368.png"
+                "url": "./assets/newspaper/Light/46.png"
             },
             "logoDark": {
-                "url": "https://s.pstatic.net/static/newsstand/2020/logo/dark/0604/368.png"
+                "url": "./assets/newspaper/Dark/46.png"
             },
             "regDate": "20230717 11:17:17"
         }
@@ -3669,10 +3669,10 @@
             "pid": "47",
             "name": "중앙일보",
             "logoLight": {
-                "url": "https://s.pstatic.net/static/newsstand/2020/logo/light/0604/363.png"
+                "url": "./assets/newspaper/Light/47.png"
             },
             "logoDark": {
-                "url": "https://s.pstatic.net/static/newsstand/2020/logo/dark/0604/363.png"
+                "url": "./assets/newspaper/Dark/47.png"
             },
             "regDate": "20230717 09:06:20"
         },
@@ -3747,10 +3747,10 @@
             "pid": "48",
             "name": "서울신문",
             "logoLight": {
-                "url": "https://s.pstatic.net/static/newsstand/2020/logo/light/0604/338.png"
+                "url": "./assets/newspaper/Light/48.png"
             },
             "logoDark": {
-                "url": "https://s.pstatic.net/static/newsstand/2020/logo/dark/0604/338.png"
+                "url": "./assets/newspaper/Dark/48.png"
             },
             "regDate": "20230716 21:36:43"
         },
@@ -3825,10 +3825,10 @@
             "pid": "49",
             "name": "스포츠조선",
             "logoLight": {
-                "url": "https://s.pstatic.net/static/newsstand/2020/logo/light/0604/340.png"
+                "url": "./assets/newspaper/Light/49.png"
             },
             "logoDark": {
-                "url": "https://s.pstatic.net/static/newsstand/2020/logo/dark/0604/340.png"
+                "url": "./assets/newspaper/Dark/49.png"
             },
             "regDate": "20230717 10:37:44"
         },
@@ -3903,10 +3903,10 @@
             "pid": "50",
             "name": "전자신문",
             "logoLight": {
-                "url": "https://s.pstatic.net/static/newsstand/up/2022/0331/nsd155937506.png"
+                "url": "./assets/newspaper/Light/50.png"
             },
             "logoDark": {
-                "url": "https://s.pstatic.net/static/newsstand/up/2022/0331/nsd15594915.png"
+                "url": "./assets/newspaper/Dark/50.png"
             },
             "regDate": "20230717 11:20:04"
         },
@@ -3981,10 +3981,10 @@
             "pid": "51",
             "name": "한국경제TV",
             "logoLight": {
-                "url": "https://s.pstatic.net/static/newsstand/2020/logo/light/0604/330.png"
+                "url": "./assets/newspaper/Light/51.png"
             },
             "logoDark": {
-                "url": "https://s.pstatic.net/static/newsstand/2020/logo/dark/0604/330.png"
+                "url": "./assets/newspaper/Dark/51.png"
             },
             "regDate": "20230717 10:43:52"
         },
@@ -4059,10 +4059,10 @@
             "pid": "52",
             "name": "BLOTER",
             "logoLight": {
-                "url": "https://s.pstatic.net/static/newsstand/2020/logo/light/0604/539.png"
+                "url": "./assets/newspaper/Light/52.png"
             },
             "logoDark": {
-                "url": "https://s.pstatic.net/static/newsstand/2020/logo/dark/0604/539.png"
+                "url": "./assets/newspaper/Dark/52.png"
             },
             "regDate": "20230717 11:31:07"
         },
@@ -4137,10 +4137,10 @@
             "pid": "53",
             "name": "KBS",
             "logoLight": {
-                "url": "https://s.pstatic.net/static/newsstand/2020/logo/light/0604/355.png"
+                "url": "./assets/newspaper/Light/53.png"
             },
             "logoDark": {
-                "url": "https://s.pstatic.net/static/newsstand/2020/logo/dark/0604/355.png"
+                "url": "./assets/newspaper/Dark/53.png"
             },
             "regDate": "20230714 10:41:16"
         },
@@ -4215,10 +4215,10 @@
             "pid": "54",
             "name": "동아일보",
             "logoLight": {
-                "url": "https://s.pstatic.net/static/newsstand/2020/logo/light/0604/337.png"
+                "url": "./assets/newspaper/Light/54.png"
             },
             "logoDark": {
-                "url": "https://s.pstatic.net/static/newsstand/2020/logo/dark/0604/337.png"
+                "url": "./assets/newspaper/Dark/54.png"
             },
             "regDate": "20230717 05:37:59"
         },
@@ -4293,10 +4293,10 @@
             "pid": "55",
             "name": "이데일리",
             "logoLight": {
-                "url": "https://s.pstatic.net/static/newsstand/2020/logo/light/0604/389.png"
+                "url": "./assets/newspaper/Light/55.png"
             },
             "logoDark": {
-                "url": "https://s.pstatic.net/static/newsstand/2020/logo/dark/0604/389.png"
+                "url": "./assets/newspaper/Dark/55.png"
             },
             "regDate": "20230717 11:20:37"
         }
@@ -4373,10 +4373,10 @@
             "pid": "56",
             "name": "뉴시스",
             "logoLight": {
-                "url": "https://s.pstatic.net/static/newsstand/2020/logo/light/0604/539.png"
+                "url": "./assets/newspaper/Light/56.png"
             },
             "logoDark": {
-                "url": "https://s.pstatic.net/static/newsstand/2020/logo/dark/0604/539.png"
+                "url": "./assets/newspaper/Dark/56.png"
             },
             "regDate": "20230717 11:31:07"
         },
@@ -4451,10 +4451,10 @@
             "pid": "57",
             "name": "한국경제",
             "logoLight": {
-                "url": "https://s.pstatic.net/static/newsstand/2020/logo/light/0604/417.png"
+                "url": "./assets/newspaper/Light/57.png"
             },
             "logoDark": {
-                "url": "https://s.pstatic.net/static/newsstand/2020/logo/dark/0604/417.png"
+                "url": "./assets/newspaper/Dark/57.png"
             },
             "regDate": "20230717 11:30:06"
         },
@@ -4529,10 +4529,10 @@
             "pid": "58",
             "name": "시사IN",
             "logoLight": {
-                "url": "https://s.pstatic.net/static/newsstand/2020/logo/light/0604/327.png"
+                "url": "./assets/newspaper/Light/58.png"
             },
             "logoDark": {
-                "url": "https://s.pstatic.net/static/newsstand/2020/logo/dark/0604/327.png"
+                "url": "./assets/newspaper/Dark/58.png"
             },
             "regDate": "20230717 11:20:10"
         },
@@ -4607,10 +4607,10 @@
             "pid": "59",
             "name": "월간산",
             "logoLight": {
-                "url": "https://s.pstatic.net/static/newsstand/up/2022/0331/nsd155937506.png"
+                "url": "./assets/newspaper/Light/59.png"
             },
             "logoDark": {
-                "url": "https://s.pstatic.net/static/newsstand/up/2022/0331/nsd15594915.png"
+                "url": "./assets/newspaper/Dark/59.png"
             },
             "regDate": "20230717 11:20:04"
         },
@@ -4685,10 +4685,10 @@
             "pid": "60",
             "name": "독서신문",
             "logoLight": {
-                "url": "https://s.pstatic.net/static/newsstand/2020/logo/light/0604/331.png"
+                "url": "./assets/newspaper/Light/60.png"
             },
             "logoDark": {
-                "url": "https://s.pstatic.net/static/newsstand/2020/logo/dark/0604/331.png"
+                "url": "./assets/newspaper/Dark/60.png"
             },
             "regDate": "20230716 18:27:01"
         },
@@ -4763,10 +4763,10 @@
             "pid": "61",
             "name": "이코노타임즈",
             "logoLight": {
-                "url": "https://s.pstatic.net/static/newsstand/2020/logo/light/0604/332.png"
+                "url": "./assets/newspaper/Light/61.png"
             },
             "logoDark": {
-                "url": "https://s.pstatic.net/static/newsstand/2020/logo/dark/0604/332.png"
+                "url": "./assets/newspaper/Dark/61.png"
             },
             "regDate": "20230717 09:06:12"
         },
@@ -4841,10 +4841,10 @@
             "pid": "62",
             "name": "TJB대전방송",
             "logoLight": {
-                "url": "https://s.pstatic.net/static/newsstand/up/2020/1228/nsd1681569.png"
+                "url": "./assets/newspaper/Light/62.png"
             },
             "logoDark": {
-                "url": "https://s.pstatic.net/static/newsstand/up/2020/1228/nsd1688305.png"
+                "url": "./assets/newspaper/Dark/62.png"
             },
             "regDate": "20230717 11:31:07"
         },
@@ -4919,10 +4919,10 @@
             "pid": "63",
             "name": "시사오늘 시사IN",
             "logoLight": {
-                "url": "https://s.pstatic.net/static/newsstand/2020/logo/light/0604/355.png"
+                "url": "./assets/newspaper/Light/63.png"
             },
             "logoDark": {
-                "url": "https://s.pstatic.net/static/newsstand/2020/logo/dark/0604/355.png"
+                "url": "./assets/newspaper/Dark/63.png"
             },
             "regDate": "20230714 10:41:16"
         },
@@ -4997,10 +4997,10 @@
             "pid": "64",
             "name": "데일리한국",
             "logoLight": {
-                "url": "https://s.pstatic.net/static/newsstand/2020/logo/light/0604/447.png"
+                "url": "./assets/newspaper/Light/64.png"
             },
             "logoDark": {
-                "url": "https://s.pstatic.net/static/newsstand/2020/logo/dark/0604/447.png"
+                "url": "./assets/newspaper/Dark/64.png"
             },
             "regDate": "20230717 08:45:34"
         },
@@ -5075,10 +5075,10 @@
             "pid": "65",
             "name": "뉴스토마토",
             "logoLight": {
-                "url": "https://s.pstatic.net/static/newsstand/up/2023/0418/nsd124959421.png"
+                "url": "./assets/newspaper/Light/65.png"
             },
             "logoDark": {
-                "url": "https://s.pstatic.net/static/newsstand/up/2023/0418/nsd124945796.png"
+                "url": "./assets/newspaper/Dark/65.png"
             },
             "regDate": "20230717 11:30:46"
         }

--- a/pressData.json
+++ b/pressData.json
@@ -67,7 +67,14 @@
                 "_id": "64b0b0265cea28d2db2e39a7"
             }
         ],
-        "name": "머니투데이"
+        "name": "머니투데이",
+        "logoLight": {
+            "url": "./assets/newspaper/Light/1.png"
+        },
+        "logoDark": {
+            "url": "./assets/newspaper/Light/1.png"
+        },
+        "regDate": "20230717 11:10:36"
     },
     "2": {
         "materials": [
@@ -137,7 +144,14 @@
                 "_id": "643542ba1f0f6898fc221bd7"
             }
         ],
-        "name": "경향신문"
+        "name": "경향신문",
+        "logoLight": {
+            "url": "./assets/newspaper/Light/2.png"
+        },
+        "logoDark": {
+            "url": "./assets/newspaper/Light/2.png"
+        },
+        "regDate": "20230713 09:58:00"
     },
     "3": {
         "materials": [
@@ -207,7 +221,14 @@
                 "_id": "646563463e93486eac614c34"
             }
         ],
-        "name": "뉴스타파"
+        "name": "뉴스타파",
+        "logoLight": {
+            "url": "./assets/newspaper/Light/3.png"
+        },
+        "logoDark": {
+            "url": "./assets/newspaper/Light/3.png"
+        },
+        "regDate": "20230717 08:45:34"
     },
     "4": {
         "materials": [
@@ -277,7 +298,14 @@
                 "_id": "64a67a2a3e93486eac6d4ead"
             }
         ],
-        "name": "오마이뉴스"
+        "name": "오마이뉴스",
+        "logoLight": {
+            "url": "./assets/newspaper/Light/4.png"
+        },
+        "logoDark": {
+            "url": "./assets/newspaper/Light/4.png"
+        },
+        "regDate": "20230717 10:37:44"
     },
     "5": {
         "materials": [
@@ -347,7 +375,14 @@
                 "_id": "643542ba1f0f6898fc221bd7"
             }
         ],
-        "name": "데일리안"
+        "name": "데일리안",
+        "logoLight": {
+            "url": "./assets/newspaper/Light/5.png"
+        },
+        "logoDark": {
+            "url": "./assets/newspaper/Light/5.png"
+        },
+        "regDate": "20230713 09:58:00"
     },
     "6": {
         "materials": [
@@ -417,7 +452,14 @@
                 "_id": "643542ba1f0f6898fc22214f"
             }
         ],
-        "name": "스포츠서울"
+        "name": "스포츠서울",
+        "logoLight": {
+            "url": "./assets/newspaper/Light/6.png"
+        },
+        "logoDark": {
+            "url": "./assets/newspaper/Light/6.png"
+        },
+        "regDate": "20230716 18:27:01"
     },
     "7": {
         "materials": [
@@ -487,7 +529,14 @@
                 "_id": "64997f72530d8014e0f35b0a"
             }
         ],
-        "name": "스포츠동아"
+        "name": "스포츠동아",
+        "logoLight": {
+            "url": "./assets/newspaper/Light/7.png"
+        },
+        "logoDark": {
+            "url": "./assets/newspaper/Light/7.png"
+        },
+        "regDate": "20230717 11:01:04"
     },
     "8": {
         "materials": [
@@ -557,7 +606,14 @@
                 "_id": "649673e740d2947ae427e965"
             }
         ],
-        "name": "문화일보"
+        "name": "문화일보",
+        "logoLight": {
+            "url": "./assets/newspaper/Light/8.png"
+        },
+        "logoDark": {
+            "url": "./assets/newspaper/Light/8.png"
+        },
+        "regDate": "20230717 10:27:57"
     },
     "9": {
         "materials": [
@@ -627,7 +683,14 @@
                 "_id": "64a69d1558a9ce6eb3c6d2e8"
             }
         ],
-        "name": "KBS World"
+        "name": "KBS World",
+        "logoLight": {
+            "url": "./assets/newspaper/Light/9.png"
+        },
+        "logoDark": {
+            "url": "./assets/newspaper/Light/9.png"
+        },
+        "regDate": "20230717 10:35:16"
     },
     "10": {
         "materials": [
@@ -697,7 +760,14 @@
                 "_id": "64b2dfd57dd28a7aefc56774"
             }
         ],
-        "name": "한국중앙데일리"
+        "name": "한국중앙데일리",
+        "logoLight": {
+            "url": "./assets/newspaper/Light/10.png"
+        },
+        "logoDark": {
+            "url": "./assets/newspaper/Light/10.png"
+        },
+        "regDate": "20230717 11:10:03"
     },
     "11": {
         "materials": [
@@ -767,7 +837,14 @@
                 "_id": "6445133d1f0f6898fc24ddc4"
             }
         ],
-        "name": "인사이트"
+        "name": "인사이트",
+        "logoLight": {
+            "url": "./assets/newspaper/Light/11.png"
+        },
+        "logoDark": {
+            "url": "./assets/newspaper/Light/11.png"
+        },
+        "regDate": "20230717 10:33:59"
     },
     "12": {
         "materials": [
@@ -837,7 +914,14 @@
                 "_id": "64b4a4a660f3c014e7afd1aa"
             }
         ],
-        "name": "법률방송뉴스"
+        "name": "법률방송뉴스",
+        "logoLight": {
+            "url": "./assets/newspaper/Light/12.png"
+        },
+        "logoDark": {
+            "url": "./assets/newspaper/Light/12.png"
+        },
+        "regDate": "20230717 11:10:46"
     },
     "13": {
         "materials": [
@@ -907,7 +991,14 @@
                 "_id": "64aba8f758a9ce6eb3c7c619"
             }
         ],
-        "name": "시사저널"
+        "name": "시사저널",
+        "logoLight": {
+            "url": "./assets/newspaper/Light/13.png"
+        },
+        "logoDark": {
+            "url": "./assets/newspaper/Light/13.png"
+        },
+        "regDate": "20230717 10:53:42"
     },
     "14": {
         "materials": [
@@ -977,7 +1068,14 @@
                 "_id": "64aba8f758a9ce6eb3c7c619"
             }
         ],
-        "name": "조이뉴스"
+        "name": "조이뉴스",
+        "logoLight": {
+            "url": "./assets/newspaper/Light/14.png"
+        },
+        "logoDark": {
+            "url": "./assets/newspaper/Light/14.png"
+        },
+        "regDate": "20230717 10:53:42"
     },
     "15": {
         "materials": [
@@ -1047,7 +1145,14 @@
                 "_id": "64b284a8e82d6f14f22b4cc4"
             }
         ],
-        "name": "헤럴드경제"
+        "name": "헤럴드경제",
+        "logoLight": {
+            "url": "./assets/newspaper/Light/15.png"
+        },
+        "logoDark": {
+            "url": "./assets/newspaper/Light/15.png"
+        },
+        "regDate": "20230717 11:10:38"
     },
     "16": {
         "materials": [
@@ -1117,7 +1222,14 @@
                 "_id": "64b4a4a660f3c014e7afd1aa"
             }
         ],
-        "name": "에너지경제"
+        "name": "에너지경제",
+        "logoLight": {
+            "url": "./assets/newspaper/Light/16.png"
+        },
+        "logoDark": {
+            "url": "./assets/newspaper/Light/16.png"
+        },
+        "regDate": "20230717 11:10:46"
     },
     "17": {
         "materials": [
@@ -1187,7 +1299,14 @@
                 "_id": "64a323283e93486eac6c92ec"
             }
         ],
-        "name": "비즈니스포스트"
+        "name": "비즈니스포스트",
+        "logoLight": {
+            "url": "./assets/newspaper/Light/17.png"
+        },
+        "logoDark": {
+            "url": "./assets/newspaper/Light/17.png"
+        },
+        "regDate": "20230717 10:00:00"
     },
     "18": {
         "materials": [
@@ -1257,7 +1376,14 @@
                 "_id": "64b13f1c58a9ce6eb3c90728"
             }
         ],
-        "name": "스코어데일리"
+        "name": "스코어데일리",
+        "logoLight": {
+            "url": "./assets/newspaper/Light/18.png"
+        },
+        "logoDark": {
+            "url": "./assets/newspaper/Light/18.png"
+        },
+        "regDate": "20230717 11:10:10"
     },
     "19": {
         "materials": [
@@ -1327,7 +1453,14 @@
                 "_id": "6445133d1f0f6898fc24ddc4"
             }
         ],
-        "name": "KNN"
+        "name": "KNN",
+        "logoLight": {
+            "url": "./assets/newspaper/Light/19.png"
+        },
+        "logoDark": {
+            "url": "./assets/newspaper/Light/19.png"
+        },
+        "regDate": "20230717 10:33:59"
     },
     "20": {
         "materials": [
@@ -1397,7 +1530,14 @@
                 "_id": "643542ba1f0f6898fc221bd7"
             }
         ],
-        "name": "한국헤럴드"
+        "name": "한국헤럴드",
+        "logoLight": {
+            "url": "./assets/newspaper/Light/20.png"
+        },
+        "logoDark": {
+            "url": "./assets/newspaper/Light/20.png"
+        },
+        "regDate": "20230713 09:58:00"
     },
     "21": {
         "materials": [
@@ -1467,7 +1607,14 @@
                 "_id": "64b08cc0c499cc07f34a3e17"
             }
         ],
-        "name": "MBC"
+        "name": "MBC",
+        "logoLight": {
+            "url": "./assets/newspaper/Light/21.png"
+        },
+        "logoDark": {
+            "url": "./assets/newspaper/Light/21.png"
+        },
+        "regDate": "20230717 11:06:35"
     },
     "22": {
         "materials": [
@@ -1537,7 +1684,14 @@
                 "_id": "64aa8f3b40d2947ae42c039e"
             }
         ],
-        "name": "뉴데일리"
+        "name": "뉴데일리",
+        "logoLight": {
+            "url": "./assets/newspaper/Light/22.png"
+        },
+        "logoDark": {
+            "url": "./assets/newspaper/Light/22.png"
+        },
+        "regDate": "20230717 11:08:52"
     },
     "23": {
         "materials": [
@@ -1607,7 +1761,14 @@
                 "_id": "643542ba1f0f6898fc222187"
             }
         ],
-        "name": "국민일보"
+        "name": "국민일보",
+        "logoLight": {
+            "url": "./assets/newspaper/Light/23.png"
+        },
+        "logoDark": {
+            "url": "./assets/newspaper/Light/23.png"
+        },
+        "regDate": "20230717 09:34:24"
     },
     "24": {
         "materials": [
@@ -1677,7 +1838,14 @@
                 "_id": "64b3d1f51f0f6898fc3a224e"
             }
         ],
-        "name": "일간스포츠"
+        "name": "일간스포츠",
+        "logoLight": {
+            "url": "./assets/newspaper/Light/24.png"
+        },
+        "logoDark": {
+            "url": "./assets/newspaper/Light/24.png"
+        },
+        "regDate": "20230717 11:20:04"
     },
     "25": {
         "materials": [
@@ -1747,7 +1915,14 @@
                 "_id": "64b17417e9bedeca622c07f8"
             }
         ],
-        "name": "ZDNET Korea"
+        "name": "ZDNET Korea",
+        "logoLight": {
+            "url": "./assets/newspaper/Light/25.png"
+        },
+        "logoDark": {
+            "url": "./assets/newspaper/Light/25.png"
+        },
+        "regDate": "20230717 11:10:05"
     },
     "26": {
         "materials": [
@@ -1817,7 +1992,14 @@
                 "_id": "648bf6ed6e592107d2de428b"
             }
         ],
-        "name": "마이데일리"
+        "name": "마이데일리",
+        "logoLight": {
+            "url": "./assets/newspaper/Light/26.png"
+        },
+        "logoDark": {
+            "url": "./assets/newspaper/Light/26.png"
+        },
+        "regDate": "20230717 10:59:06"
     },
     "27": {
         "materials": [
@@ -1887,7 +2069,14 @@
                 "_id": "64b284a8e82d6f14f22b4cc4"
             }
         ],
-        "name": "SBS"
+        "name": "SBS",
+        "logoLight": {
+            "url": "./assets/newspaper/Light/27.png"
+        },
+        "logoDark": {
+            "url": "./assets/newspaper/Light/27.png"
+        },
+        "regDate": "20230717 11:10:38"
     },
     "28": {
         "materials": [
@@ -1957,7 +2146,14 @@
                 "_id": "64ac235223adad7ad2994cdf"
             }
         ],
-        "name": "서울경제"
+        "name": "서울경제",
+        "logoLight": {
+            "url": "./assets/newspaper/Light/28.png"
+        },
+        "logoDark": {
+            "url": "./assets/newspaper/Light/28.png"
+        },
+        "regDate": "20230717 11:22:16"
     },
     "29": {
         "materials": [
@@ -2027,7 +2223,14 @@
                 "_id": "64b0d968052e097ad990e7b0"
             }
         ],
-        "name": "매일경제"
+        "name": "매일경제",
+        "logoLight": {
+            "url": "./assets/newspaper/Light/29.png"
+        },
+        "logoDark": {
+            "url": "./assets/newspaper/Light/29.png"
+        },
+        "regDate": "20230717 11:20:02"
     },
     "30": {
         "materials": [
@@ -2097,7 +2300,14 @@
                 "_id": "649673e740d2947ae427e965"
             }
         ],
-        "name": "MBN"
+        "name": "MBN",
+        "logoLight": {
+            "url": "./assets/newspaper/Light/30.png"
+        },
+        "logoDark": {
+            "url": "./assets/newspaper/Light/30.png"
+        },
+        "regDate": "20230717 11:20:31"
     },
     "31": {
         "materials": [
@@ -2167,7 +2377,14 @@
                 "_id": "64a69d1558a9ce6eb3c6d2e8"
             }
         ],
-        "name": "YTN"
+        "name": "YTN",
+        "logoLight": {
+            "url": "./assets/newspaper/Light/31.png"
+        },
+        "logoDark": {
+            "url": "./assets/newspaper/Light/31.png"
+        },
+        "regDate": "20230717 10:35:16"
     },
     "32": {
         "materials": [
@@ -2237,7 +2454,14 @@
                 "_id": "648bf6ed6e592107d2de428b"
             }
         ],
-        "name": "시사위크"
+        "name": "시사위크",
+        "logoLight": {
+            "url": "./assets/newspaper/Light/32.png"
+        },
+        "logoDark": {
+            "url": "./assets/newspaper/Light/32.png"
+        },
+        "regDate": "20230717 10:59:06"
     },
     "33": {
         "materials": [
@@ -2307,7 +2531,14 @@
                 "_id": "644220ca548a597b72bed48c"
             }
         ],
-        "name": "세계일보"
+        "name": "세계일보",
+        "logoLight": {
+            "url": "./assets/newspaper/Light/33.png"
+        },
+        "logoDark": {
+            "url": "./assets/newspaper/Light/33.png"
+        },
+        "regDate": "20230715 06:51:19"
     },
     "34": {
         "materials": [
@@ -2377,7 +2608,14 @@
                 "_id": "643542ba1f0f6898fc222148"
             }
         ],
-        "name": "디지털투데이"
+        "name": "디지털투데이",
+        "logoLight": {
+            "url": "./assets/newspaper/Light/34.png"
+        },
+        "logoDark": {
+            "url": "./assets/newspaper/Light/34.png"
+        },
+        "regDate": "20230717 10:43:52"
     },
     "35": {
         "materials": [
@@ -2447,7 +2685,14 @@
                 "_id": "644220ca548a597b72bed48c"
             }
         ],
-        "name": "데이터뉴스"
+        "name": "데이터뉴스",
+        "logoLight": {
+            "url": "./assets/newspaper/Light/35.png"
+        },
+        "logoDark": {
+            "url": "./assets/newspaper/Light/35.png"
+        },
+        "regDate": "20230715 06:51:19"
     },
     "36": {
         "materials": [
@@ -2517,7 +2762,14 @@
                 "_id": "64997f72530d8014e0f35b0a"
             }
         ],
-        "name": "한국대학신문"
+        "name": "한국대학신문",
+        "logoLight": {
+            "url": "./assets/newspaper/Light/36.png"
+        },
+        "logoDark": {
+            "url": "./assets/newspaper/Light/36.png"
+        },
+        "regDate": "20230717 11:01:04"
     },
     "37": {
         "materials": [
@@ -2587,7 +2839,14 @@
                 "_id": "643542ba1f0f6898fc222195"
             }
         ],
-        "name": "서울파이낸스"
+        "name": "서울파이낸스",
+        "logoLight": {
+            "url": "./assets/newspaper/Light/37.png"
+        },
+        "logoDark": {
+            "url": "./assets/newspaper/Light/37.png"
+        },
+        "regDate": "20230716 21:36:43"
     },
     "38": {
         "materials": [
@@ -2657,7 +2916,14 @@
                 "_id": "64b0dbfc548a597b72d3cdf5"
             }
         ],
-        "name": "엑스포스뉴스"
+        "name": "엑스포스뉴스",
+        "logoLight": {
+            "url": "./assets/newspaper/Light/38.png"
+        },
+        "logoDark": {
+            "url": "./assets/newspaper/Light/38.png"
+        },
+        "regDate": "20230717 11:22:20"
     },
     "39": {
         "materials": [
@@ -2727,7 +2993,14 @@
                 "_id": "643542ba1f0f6898fc2220c3"
             }
         ],
-        "name": "맥스무비"
+        "name": "맥스무비",
+        "logoLight": {
+            "url": "./assets/newspaper/Light/39.png"
+        },
+        "logoDark": {
+            "url": "./assets/newspaper/Light/39.png"
+        },
+        "regDate": "20230717 08:56:59"
     },
     "40": {
         "materials": [
@@ -2797,7 +3070,14 @@
                 "_id": "64b284a8e82d6f14f22b4cc4"
             }
         ],
-        "name": "OBS"
+        "name": "OBS",
+        "logoLight": {
+            "url": "./assets/newspaper/Light/40.png"
+        },
+        "logoDark": {
+            "url": "./assets/newspaper/Light/40.png"
+        },
+        "regDate": "20230717 11:20:37"
     },
     "41": {
         "materials": [
@@ -2867,7 +3147,14 @@
                 "_id": "645635d040d2947ae41be55a"
             }
         ],
-        "name": "소년한국일보"
+        "name": "소년한국일보",
+        "logoLight": {
+            "url": "./assets/newspaper/Light/41.png"
+        },
+        "logoDark": {
+            "url": "./assets/newspaper/Light/41.png"
+        },
+        "regDate": "20230716 18:27:27"
     },
     "42": {
         "materials": [
@@ -2937,7 +3224,14 @@
                 "_id": "64a67a2a3e93486eac6d4ead"
             }
         ],
-        "name": "한국일보"
+        "name": "한국일보",
+        "logoLight": {
+            "url": "./assets/newspaper/Light/42.png"
+        },
+        "logoDark": {
+            "url": "./assets/newspaper/Light/42.png"
+        },
+        "regDate": "20230717 10:37:44"
     },
     "43": {
         "materials": [
@@ -3007,7 +3301,14 @@
                 "_id": "643542ba1f0f6898fc222195"
             }
         ],
-        "name": "Sportal korea"
+        "name": "Sportal korea",
+        "logoLight": {
+            "url": "./assets/newspaper/Light/43.png"
+        },
+        "logoDark": {
+            "url": "./assets/newspaper/Light/43.png"
+        },
+        "regDate": "20230716 21:36:43"
     },
     "44": {
         "materials": [
@@ -3077,7 +3378,14 @@
                 "_id": "643542ba1f0f6898fc2220c3"
             }
         ],
-        "name": "아시아경제"
+        "name": "아시아경제",
+        "logoLight": {
+            "url": "./assets/newspaper/Light/44.png"
+        },
+        "logoDark": {
+            "url": "./assets/newspaper/Light/44.png"
+        },
+        "regDate": "20230717 08:56:59"
     },
     "45": {
         "materials": [
@@ -3147,7 +3455,14 @@
                 "_id": "643542ba1f0f6898fc221bc2"
             }
         ],
-        "name": "프레시안"
+        "name": "프레시안",
+        "logoLight": {
+            "url": "./assets/newspaper/Light/45.png"
+        },
+        "logoDark": {
+            "url": "./assets/newspaper/Light/45.png"
+        },
+        "regDate": "20230717 09:06:20"
     },
     "46": {
         "materials": [
@@ -3217,7 +3532,14 @@
                 "_id": "64aa8f3b40d2947ae42c039e"
             }
         ],
-        "name": "노컷뉴스"
+        "name": "노컷뉴스",
+        "logoLight": {
+            "url": "./assets/newspaper/Light/46.png"
+        },
+        "logoDark": {
+            "url": "./assets/newspaper/Light/46.png"
+        },
+        "regDate": "20230717 11:17:17"
     },
     "47": {
         "materials": [
@@ -3287,7 +3609,14 @@
                 "_id": "643542ba1f0f6898fc221bc2"
             }
         ],
-        "name": "중앙일보"
+        "name": "중앙일보",
+        "logoLight": {
+            "url": "./assets/newspaper/Light/47.png"
+        },
+        "logoDark": {
+            "url": "./assets/newspaper/Light/47.png"
+        },
+        "regDate": "20230717 09:06:20"
     },
     "48": {
         "materials": [
@@ -3357,7 +3686,14 @@
                 "_id": "643542ba1f0f6898fc222195"
             }
         ],
-        "name": "서울신문"
+        "name": "서울신문",
+        "logoLight": {
+            "url": "./assets/newspaper/Light/48.png"
+        },
+        "logoDark": {
+            "url": "./assets/newspaper/Light/48.png"
+        },
+        "regDate": "20230716 21:36:43"
     },
     "49": {
         "materials": [
@@ -3427,7 +3763,14 @@
                 "_id": "64a67a2a3e93486eac6d4ead"
             }
         ],
-        "name": "스포츠조선"
+        "name": "스포츠조선",
+        "logoLight": {
+            "url": "./assets/newspaper/Light/49.png"
+        },
+        "logoDark": {
+            "url": "./assets/newspaper/Light/49.png"
+        },
+        "regDate": "20230717 10:37:44"
     },
     "50": {
         "materials": [
@@ -3497,7 +3840,14 @@
                 "_id": "64b3d1f51f0f6898fc3a224e"
             }
         ],
-        "name": "전자신문"
+        "name": "전자신문",
+        "logoLight": {
+            "url": "./assets/newspaper/Light/50.png"
+        },
+        "logoDark": {
+            "url": "./assets/newspaper/Light/50.png"
+        },
+        "regDate": "20230717 11:20:04"
     },
     "51": {
         "materials": [
@@ -3567,7 +3917,14 @@
                 "_id": "643542ba1f0f6898fc222148"
             }
         ],
-        "name": "한국경제TV"
+        "name": "한국경제TV",
+        "logoLight": {
+            "url": "./assets/newspaper/Light/51.png"
+        },
+        "logoDark": {
+            "url": "./assets/newspaper/Light/51.png"
+        },
+        "regDate": "20230717 10:43:52"
     },
     "52": {
         "materials": [
@@ -3637,7 +3994,14 @@
                 "_id": "64b0dbfc548a597b72d3cdf5"
             }
         ],
-        "name": "BLOTER"
+        "name": "BLOTER",
+        "logoLight": {
+            "url": "./assets/newspaper/Light/52.png"
+        },
+        "logoDark": {
+            "url": "./assets/newspaper/Light/52.png"
+        },
+        "regDate": "20230717 11:31:07"
     },
     "53": {
         "materials": [
@@ -3707,7 +4071,14 @@
                 "_id": "643542ba1f0f6898fc221b60"
             }
         ],
-        "name": "KBS"
+        "name": "KBS",
+        "logoLight": {
+            "url": "./assets/newspaper/Light/53.png"
+        },
+        "logoDark": {
+            "url": "./assets/newspaper/Light/53.png"
+        },
+        "regDate": "20230714 10:41:16"
     },
     "54": {
         "materials": [
@@ -3777,7 +4148,14 @@
                 "_id": "64a374b9824d90d2cc4097ac"
             }
         ],
-        "name": "동아일보"
+        "name": "동아일보",
+        "logoLight": {
+            "url": "./assets/newspaper/Light/54.png"
+        },
+        "logoDark": {
+            "url": "./assets/newspaper/Light/54.png"
+        },
+        "regDate": "20230717 05:37:59"
     },
     "55": {
         "materials": [
@@ -3847,7 +4225,14 @@
                 "_id": "64b284a8e82d6f14f22b4cc4"
             }
         ],
-        "name": "이데일리"
+        "name": "이데일리",
+        "logoLight": {
+            "url": "./assets/newspaper/Light/55.png"
+        },
+        "logoDark": {
+            "url": "./assets/newspaper/Light/55.png"
+        },
+        "regDate": "20230717 11:20:37"
     },
     "56": {
         "materials": [
@@ -3917,7 +4302,14 @@
                 "_id": "64b0dbfc548a597b72d3cdf5"
             }
         ],
-        "name": "뉴시스"
+        "name": "뉴시스",
+        "logoLight": {
+            "url": "./assets/newspaper/Light/56.png"
+        },
+        "logoDark": {
+            "url": "./assets/newspaper/Light/56.png"
+        },
+        "regDate": "20230717 11:31:07"
     },
     "57": {
         "materials": [
@@ -3987,7 +4379,14 @@
                 "_id": "64b17417e9bedeca622c07f8"
             }
         ],
-        "name": "한국경제"
+        "name": "한국경제",
+        "logoLight": {
+            "url": "./assets/newspaper/Light/57.png"
+        },
+        "logoDark": {
+            "url": "./assets/newspaper/Light/57.png"
+        },
+        "regDate": "20230717 11:30:06"
     },
     "58": {
         "materials": [
@@ -4057,7 +4456,14 @@
                 "_id": "64ada11f3c50cd9912fbe55e"
             }
         ],
-        "name": "시사IN"
+        "name": "시사IN",
+        "logoLight": {
+            "url": "./assets/newspaper/Light/58.png"
+        },
+        "logoDark": {
+            "url": "./assets/newspaper/Light/58.png"
+        },
+        "regDate": "20230717 11:20:10"
     },
     "59": {
         "materials": [
@@ -4127,7 +4533,14 @@
                 "_id": "64b3d1f51f0f6898fc3a224e"
             }
         ],
-        "name": "월간산"
+        "name": "월간산",
+        "logoLight": {
+            "url": "./assets/newspaper/Light/59.png"
+        },
+        "logoDark": {
+            "url": "./assets/newspaper/Light/59.png"
+        },
+        "regDate": "20230717 11:20:04"
     },
     "60": {
         "materials": [
@@ -4197,7 +4610,14 @@
                 "_id": "643542ba1f0f6898fc22214f"
             }
         ],
-        "name": "독서신문"
+        "name": "독서신문",
+        "logoLight": {
+            "url": "./assets/newspaper/Light/60.png"
+        },
+        "logoDark": {
+            "url": "./assets/newspaper/Light/60.png"
+        },
+        "regDate": "20230716 18:27:01"
     },
     "61": {
         "materials": [
@@ -4267,7 +4687,14 @@
                 "_id": "64ad7df27a6b147b6bf89733"
             }
         ],
-        "name": "이코노타임즈"
+        "name": "이코노타임즈",
+        "logoLight": {
+            "url": "./assets/newspaper/Light/61.png"
+        },
+        "logoDark": {
+            "url": "./assets/newspaper/Light/61.png"
+        },
+        "regDate": "20230717 09:06:12"
     },
     "62": {
         "materials": [
@@ -4337,7 +4764,14 @@
                 "_id": "64b4912f57629c14fd0b95df"
             }
         ],
-        "name": "TJB대전방송"
+        "name": "TJB대전방송",
+        "logoLight": {
+            "url": "./assets/newspaper/Light/62.png"
+        },
+        "logoDark": {
+            "url": "./assets/newspaper/Light/62.png"
+        },
+        "regDate": "20230717 11:31:07"
     },
     "63": {
         "materials": [
@@ -4407,7 +4841,14 @@
                 "_id": "643542ba1f0f6898fc221b60"
             }
         ],
-        "name": "시사오늘 시사IN"
+        "name": "시사오늘 시사IN",
+        "logoLight": {
+            "url": "./assets/newspaper/Light/63.png"
+        },
+        "logoDark": {
+            "url": "./assets/newspaper/Light/63.png"
+        },
+        "regDate": "20230714 10:41:16"
     },
     "64": {
         "materials": [
@@ -4477,7 +4918,14 @@
                 "_id": "646563463e93486eac614c34"
             }
         ],
-        "name": "데일리한국"
+        "name": "데일리한국",
+        "logoLight": {
+            "url": "./assets/newspaper/Light/64.png"
+        },
+        "logoDark": {
+            "url": "./assets/newspaper/Light/64.png"
+        },
+        "regDate": "20230717 08:45:34"
     },
     "65": {
         "materials": [
@@ -4547,6 +4995,13 @@
                 "_id": "64b4a4a660f3c014e7afd1aa"
             }
         ],
-        "name": "뉴스토마토"
+        "name": "뉴스토마토",
+        "logoLight": {
+            "url": "./assets/newspaper/Light/65.png"
+        },
+        "logoDark": {
+            "url": "./assets/newspaper/Light/65.png"
+        },
+        "regDate": "20230717 11:30:46"
     }
 }

--- a/pressData.json
+++ b/pressData.json
@@ -1,0 +1,4552 @@
+{
+    "1": {
+        "materials": [
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "송정역 주차빌딩  개장 50일 곳곳 ‘하자’",
+                "url": "http://www.gjdream.com/news/articleView.html?idxno=630698",
+                "aid": "4fd117b5ddea74b5",
+                "image": {
+                    "url": "https://s.pstatic.net/dthumb.phinf/?src=%22https%3A%2F%2Fs.pstatic.net%2Fstatic%2Fnewsstand%2F2023%2F0717%2Farticle_img%2Fnew_main%2F9065%2F111451_001.jpg%22&type=nf312_208&service=navermain"
+                },
+                "_id": "643542ba1f0f6898fc22209a"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "광주시화정청소년문화의집, 서구 화정2동과 업무협약",
+                "url": "http://www.gjdream.com/news/articleView.html?idxno=630658",
+                "aid": "4fd117398cf0b639",
+                "image": null,
+                "_id": "64783d54824d90d2cc38bd47"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "광주청소년활동진흥센터 청소년정책토론회 개최",
+                "url": "http://www.gjdream.com/news/articleView.html?idxno=630647",
+                "aid": "4fd117190522c259",
+                "image": null,
+                "_id": "64b0b0265cea28d2db2e39a3"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "“다문화가정의 행복 비법을 알려드립니다”",
+                "url": "http://www.gjdream.com/news/articleView.html?idxno=629584",
+                "aid": "4fc713a7e664ad27",
+                "image": null,
+                "_id": "64b0b0265cea28d2db2e39a4"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "[시민기자 생각]재해 복구, 행정 앞장서지만   원인자도 비용 부담해야",
+                "url": "http://www.gjdream.com/news/articleView.html?idxno=630499",
+                "aid": "4fd110345c8eb7f4",
+                "image": null,
+                "_id": "64b0b0265cea28d2db2e39a5"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "[김대원의 여의도 포커스]“할 말 못 할 바엔 정치 안하는 게 낫다”",
+                "url": "http://www.gjdream.com/news/articleView.html?idxno=630650",
+                "aid": "4fd11731f0749431",
+                "image": null,
+                "_id": "64b0b0265cea28d2db2e39a6"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "광주경총 금요포럼 ‘판소리의 멋…’",
+                "url": "http://www.gjdream.com/news/articleView.html?idxno=630708",
+                "aid": "4fd11a5f622e289f",
+                "image": null,
+                "_id": "64b0b0265cea28d2db2e39a7"
+            }
+        ],
+        "name": "머니투데이"
+    },
+    "2": {
+        "materials": [
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "smartPC사랑 2023 상반기 베스트 하드웨어 어워즈 선정",
+                "url": "https://www.ilovepc.co.kr/news/articleView.html?idxno=47208",
+                "aid": "f1d10d514a4a5c51",
+                "image": {
+                    "url": "https://s.pstatic.net/dthumb.phinf/?src=%22https%3A%2F%2Fs.pstatic.net%2Fstatic%2Fnewsstand%2F2023%2F0713%2Farticle_img%2Fnew_main%2F9087%2F100252_001.jpg%22&type=nf312_208&service=navermain"
+                },
+                "_id": "643542ba1f0f6898fc221bd1"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "가성비 게이밍 그래픽카드, 인텔 아크 A750 알아보기",
+                "url": "https://www.ilovepc.co.kr/news/articleView.html?idxno=47112",
+                "aid": "f1d109a9029f0be9",
+                "image": null,
+                "_id": "643542ba1f0f6898fc221bd2"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "2023년 7월호",
+                "url": "http://www.ilovepc.co.kr",
+                "aid": "167fbf961937deaa",
+                "image": null,
+                "_id": "643542ba1f0f6898fc221bd3"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "시원시원한 디스플레이에 휴대성까지? LG전자 2023 그램16 16ZD90RU-GX56K",
+                "url": "https://www.ilovepc.co.kr/news/articleView.html?idxno=47218",
+                "aid": "f1d10d70c8ab6030",
+                "image": null,
+                "_id": "643542ba1f0f6898fc221bd4"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "[팁] 마이크론 2400 SSD로 에이수스 로그 엘라이(ASUS ROG ALLY) 용량을 간단하게 업그레이드해보자",
+                "url": "https://www.ilovepc.co.kr/news/articleView.html?idxno=47306",
+                "aid": "f1d11110a25af090",
+                "image": null,
+                "_id": "643542ba1f0f6898fc221bd5"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "게이밍도 가능한 초경량 노트북? LG전자 2023 그램17 17Z90R-ED7VK",
+                "url": "https://www.ilovepc.co.kr/news/articleView.html?idxno=47219",
+                "aid": "f1d10d71166ad831",
+                "image": null,
+                "_id": "643542ba1f0f6898fc221bd6"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "UMPC 게임기 '옥조' 배터리 폭발 2번…휴대용 게임기 폭발 사고, 다른 제품도 있었을까?",
+                "url": "https://www.ilovepc.co.kr/news/articleView.html?idxno=47357",
+                "aid": "f1d111ac67ff7bec",
+                "image": null,
+                "_id": "643542ba1f0f6898fc221bd7"
+            }
+        ],
+        "name": "경향신문"
+    },
+    "3": {
+        "materials": [
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "“아무리 싸도 억” 송지효 부모님 통영 여객선 사업 큰 손이었다(런닝맨)[어제TV]",
+                "url": "http://news.newsen.com/news_view.php?uid=202307161856566710",
+                "aid": "955ae1a0debf2520",
+                "image": {
+                    "url": "https://s.pstatic.net/dthumb.phinf/?src=%22https%3A%2F%2Fs.pstatic.net%2Fstatic%2Fnewsstand%2F2023%2F0717%2Farticle_img%2Fnew_main%2F9126%2F085139_001.jpg%22&type=nf312_208&service=navermain"
+                },
+                "_id": "643542ba1f0f6898fc222111"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "김우빈→이찬원 폭우 피해에 ★ 기부 행렬 “도움 되기를” [종합]",
+                "url": "http://news.newsen.com/news_view.php?uid=202307161637415710",
+                "aid": "cffa229e4be4541e",
+                "image": null,
+                "_id": "64382002d2afac98f57ccef6"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "빅히트 뮤직 측 “BTS 정국 유튜브 집계 문제없다”[공식]",
+                "url": "http://news.newsen.com/news_view.php?uid=202307170753070410",
+                "aid": "fa821967f7653567",
+                "image": null,
+                "_id": "645661636e592107d2d4489a"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "강동원, 정용진 부회장 쌍둥이 남매 만나 깜짝 사인회 ‘삼촌미소’",
+                "url": "http://news.newsen.com/news_view.php?uid=202307170702342410",
+                "aid": "c32b29e3313554e3",
+                "image": null,
+                "_id": "646563463e93486eac614c31"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "“열심히 드럼 칠게요” 데이식스 도운, 성진·영케이 축하 속 만기 전역[종합]",
+                "url": "http://news.newsen.com/news_view.php?uid=202307162034360410",
+                "aid": "aa8593bc17e2a6fc",
+                "image": null,
+                "_id": "646563463e93486eac614c32"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "백진희 딸 낳았다, 안재현과 1년만 운명적 재회 (진짜가)[어제TV]",
+                "url": "http://news.newsen.com/news_view.php?uid=202307170600231710",
+                "aid": "c356eb24702c63a4",
+                "image": null,
+                "_id": "646563463e93486eac614c33"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "여자아이들 미연 ‘옅은 화장에도 예쁨 폭발’[포토엔HD]",
+                "url": "http://news.newsen.com/news_view.php?uid=202307161853393510",
+                "aid": "f36760832c1cb243",
+                "image": null,
+                "_id": "646563463e93486eac614c34"
+            }
+        ],
+        "name": "뉴스타파"
+    },
+    "4": {
+        "materials": [
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "윤 대통령 \"특별재난지역 선포 등 정책 모두 동원\"",
+                "url": "http://www.obsnews.co.kr/news/articleView.html?idxno=1406756",
+                "aid": "20cbda31ed1c2f6f",
+                "image": {
+                    "url": "https://s.pstatic.net/dthumb.phinf/?src=%22https%3A%2F%2Fs.pstatic.net%2Fstatic%2Fnewsstand%2F2023%2F0717%2Farticle_img%2Fnew_main%2F9070%2F104113_001.jpg%22&type=nf312_208&service=navermain"
+                },
+                "_id": "643542ba1f0f6898fc22219d"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "아파트 복도서 흉기 난동…1명 사망·1명 경상",
+                "url": "http://www.obsnews.co.kr/news/articleView.html?idxno=1406750",
+                "aid": "20cbda2b6ffefeb5",
+                "image": null,
+                "_id": "643542ba1f0f6898fc22219e"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "바다에 아내 빠트리고 돌 던져 살해…30대 구속영장",
+                "url": "http://www.obsnews.co.kr/news/articleView.html?idxno=1406758",
+                "aid": "20cbda33c17b3fad",
+                "image": null,
+                "_id": "64868b31c499cc07f341f2da"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "경기도·융기원·경기대·장비업체 '반도체 공유대학'",
+                "url": "http://www.obsnews.co.kr/news/articleView.html?idxno=1406749",
+                "aid": "20cbda15ddeb4fcb",
+                "image": null,
+                "_id": "64868b31c499cc07f341f2db"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "\"호우 사망·실종 48명\"…집계 외 사망자 1명 늘어",
+                "url": "http://www.obsnews.co.kr/news/articleView.html?idxno=1406757",
+                "aid": "20cbda32574bb78e",
+                "image": null,
+                "_id": "64868b31c499cc07f341f2dc"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "코레일, 경강선 세종대왕릉~여주 구간 운행 재개",
+                "url": "http://www.obsnews.co.kr/news/articleView.html?idxno=1406730",
+                "aid": "20cbd9edd4800eb3",
+                "image": null,
+                "_id": "64868b31c499cc07f341f2dd"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "국회 법사위, 오늘 '영아살해·유기 처벌강화법' 처리",
+                "url": "http://www.obsnews.co.kr/news/articleView.html?idxno=1406727",
+                "aid": "20cbd9d56e0d4f8b",
+                "image": null,
+                "_id": "64a67a2a3e93486eac6d4ead"
+            }
+        ],
+        "name": "오마이뉴스"
+    },
+    "5": {
+        "materials": [
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "smartPC사랑 2023 상반기 베스트 하드웨어 어워즈 선정",
+                "url": "https://www.ilovepc.co.kr/news/articleView.html?idxno=47208",
+                "aid": "f1d10d514a4a5c51",
+                "image": {
+                    "url": "https://s.pstatic.net/dthumb.phinf/?src=%22https%3A%2F%2Fs.pstatic.net%2Fstatic%2Fnewsstand%2F2023%2F0713%2Farticle_img%2Fnew_main%2F9087%2F100252_001.jpg%22&type=nf312_208&service=navermain"
+                },
+                "_id": "643542ba1f0f6898fc221bd1"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "가성비 게이밍 그래픽카드, 인텔 아크 A750 알아보기",
+                "url": "https://www.ilovepc.co.kr/news/articleView.html?idxno=47112",
+                "aid": "f1d109a9029f0be9",
+                "image": null,
+                "_id": "643542ba1f0f6898fc221bd2"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "2023년 7월호",
+                "url": "http://www.ilovepc.co.kr",
+                "aid": "167fbf961937deaa",
+                "image": null,
+                "_id": "643542ba1f0f6898fc221bd3"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "시원시원한 디스플레이에 휴대성까지? LG전자 2023 그램16 16ZD90RU-GX56K",
+                "url": "https://www.ilovepc.co.kr/news/articleView.html?idxno=47218",
+                "aid": "f1d10d70c8ab6030",
+                "image": null,
+                "_id": "643542ba1f0f6898fc221bd4"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "[팁] 마이크론 2400 SSD로 에이수스 로그 엘라이(ASUS ROG ALLY) 용량을 간단하게 업그레이드해보자",
+                "url": "https://www.ilovepc.co.kr/news/articleView.html?idxno=47306",
+                "aid": "f1d11110a25af090",
+                "image": null,
+                "_id": "643542ba1f0f6898fc221bd5"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "게이밍도 가능한 초경량 노트북? LG전자 2023 그램17 17Z90R-ED7VK",
+                "url": "https://www.ilovepc.co.kr/news/articleView.html?idxno=47219",
+                "aid": "f1d10d71166ad831",
+                "image": null,
+                "_id": "643542ba1f0f6898fc221bd6"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "UMPC 게임기 '옥조' 배터리 폭발 2번…휴대용 게임기 폭발 사고, 다른 제품도 있었을까?",
+                "url": "https://www.ilovepc.co.kr/news/articleView.html?idxno=47357",
+                "aid": "f1d111ac67ff7bec",
+                "image": null,
+                "_id": "643542ba1f0f6898fc221bd7"
+            }
+        ],
+        "name": "데일리안"
+    },
+    "6": {
+        "materials": [
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "기록적 폭우에… 온 나라가 슬픔에 잠겼다",
+                "url": "https://www.cctoday.co.kr/news/articleView.html?idxno=2181333",
+                "aid": "99f490eae26eb2aa",
+                "image": {
+                    "url": "https://s.pstatic.net/dthumb.phinf/?src=%22https%3A%2F%2Fs.pstatic.net%2Fstatic%2Fnewsstand%2F2023%2F0716%2Farticle_img%2Fnew_main%2F9063%2F183124_001.jpg%22&type=nf312_208&service=navermain"
+                },
+                "_id": "643542ba1f0f6898fc222149"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "충남 3곳·세종 국제화특구 지정 충청권 국제화 교육 기틀 마련 기대",
+                "url": "https://www.cctoday.co.kr/news/articleView.html?idxno=2181137",
+                "aid": "99f4896cb5f5b1ac",
+                "image": null,
+                "_id": "643542ba1f0f6898fc22214a"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "손 놓는 보건의료노조 충청지역 의료공백 불가피",
+                "url": "https://www.cctoday.co.kr/news/articleView.html?idxno=2181057",
+                "aid": "99f485e93c9549e9",
+                "image": null,
+                "_id": "643542ba1f0f6898fc22214b"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "‘지방시대위’ 세종서 출범 어디서나 살기 좋은 지방시대 구현",
+                "url": "https://www.cctoday.co.kr/news/articleView.html?idxno=2180970",
+                "aid": "99f4338a4c042c0a",
+                "image": null,
+                "_id": "643542ba1f0f6898fc22214c"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "“제발” 지하차도만 하염없이 바라보는 실종자 가족들",
+                "url": "https://www.cctoday.co.kr/news/articleView.html?idxno=2181319",
+                "aid": "99f490b2349888f2",
+                "image": null,
+                "_id": "643542ba1f0f6898fc22214d"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "집안까지 들이닥친 빗물 \"살림살이 둥둥 떠다녀\"",
+                "url": "https://www.cctoday.co.kr/news/articleView.html?idxno=2181330",
+                "aid": "99f490e74f2a3f67",
+                "image": null,
+                "_id": "643542ba1f0f6898fc22214e"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "여야 지도부, 폭우 피해 입은 충북 방문 복구 지원 약속",
+                "url": "https://www.cctoday.co.kr/news/articleView.html?idxno=2181316",
+                "aid": "99f490afa15415af",
+                "image": null,
+                "_id": "643542ba1f0f6898fc22214f"
+            }
+        ],
+        "name": "스포츠서울"
+    },
+    "7": {
+        "materials": [
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "최대 200㎜ 물폭탄… 침수·산사태 위험지 수백명 긴급 대피",
+                "url": "http://www.knnews.co.kr/news/articleView.php?idxno=1409013",
+                "aid": "bf2851f8824cf908",
+                "image": {
+                    "url": "https://s.pstatic.net/dthumb.phinf/?src=%22https%3A%2F%2Fs.pstatic.net%2Fstatic%2Fnewsstand%2F2023%2F0717%2Farticle_img%2Fnew_main%2F9072%2F110825_001.jpg%22&type=nf312_208&service=navermain"
+                },
+                "_id": "643542ba1f0f6898fc222157"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "도내 침수 취약주택 30% “비용 부담돼 물막이판 설치 안 해”",
+                "url": "http://www.knnews.co.kr/news/articleView.php?idxno=1409021",
+                "aid": "bf285215791a758b",
+                "image": null,
+                "_id": "643542ba1f0f6898fc222158"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "창녕함안보 등 4대강 보 정책 ‘해체’서 ‘존치’로 바뀔 듯",
+                "url": "http://www.knnews.co.kr/news/articleView.php?idxno=1409016",
+                "aid": "bf2851fbfd7004a5",
+                "image": null,
+                "_id": "643542ba1f0f6898fc222159"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "지리산 인근 지자체 ‘케이블카 재추진’ 시끌",
+                "url": "http://www.knnews.co.kr/news/articleView.php?idxno=1409000",
+                "aid": "bf2851d6139a692a",
+                "image": null,
+                "_id": "64713b656e592107d2d9ae55"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "오염수 우려에 손님 줄었는데 장마까지… 어시장 상인 시름",
+                "url": "http://www.knnews.co.kr/news/articleView.php?idxno=1409011",
+                "aid": "bf2851f6858af14a",
+                "image": null,
+                "_id": "64997f72530d8014e0f35b08"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "보건의료노조 총파업 종료… 양산부산대병원은 파업 계속",
+                "url": "http://www.knnews.co.kr/news/articleView.php?idxno=1409018",
+                "aid": "bf2851fdfa320c63",
+                "image": null,
+                "_id": "64997f72530d8014e0f35b09"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "경남도의회 “경남TP 원장 후보 ‘유흥접대 전력’ 있을 수 있는 일”",
+                "url": "http://www.knnews.co.kr/news/articleView.php?idxno=1409022",
+                "aid": "bf285216f77b796a",
+                "image": null,
+                "_id": "64997f72530d8014e0f35b0a"
+            }
+        ],
+        "name": "스포츠동아"
+    },
+    "8": {
+        "materials": [
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "엄정화·김완선·이효리…화사는 '언니'들이 지킨다",
+                "url": "http://www.sportsworldi.com/newsView/20230717506063",
+                "aid": "4fe028c2cf60f142",
+                "image": {
+                    "url": "https://s.pstatic.net/dthumb.phinf/?src=%22https%3A%2F%2Fs.pstatic.net%2Fstatic%2Fnewsstand%2F2023%2F0717%2Farticle_img%2Fnew_main%2F9120%2F103430_001.jpg%22&type=nf312_208&service=navermain"
+                },
+                "_id": "643542ba1f0f6898fc221e6a"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "김민재 뮌헨행 공식 발표만 남았다",
+                "url": "http://www.sportsworldi.com/newsView/20230716509459",
+                "aid": "1afb59895fbb8789",
+                "image": null,
+                "_id": "649673e740d2947ae427e960"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "'알카라스의 시대' 증명한 윔블던 우승",
+                "url": "http://www.sportsworldi.com/newsView/20230717505052",
+                "aid": "4fdfb4438e7b16c3",
+                "image": null,
+                "_id": "649673e740d2947ae427e961"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "‘킹더랜드’ 이준호♥임윤아, 달빛 입맞춤",
+                "url": "http://www.sportsworldi.com/newsView/20230717505503",
+                "aid": "4fdfc66e7ca52bae",
+                "image": null,
+                "_id": "649673e740d2947ae427e962"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "송지효 \"부모님, 통영서 여객선 사업해\"",
+                "url": "http://www.sportsworldi.com/newsView/20230716516433",
+                "aid": "1b0813a9babee169",
+                "image": null,
+                "_id": "649673e740d2947ae427e963"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "한효주·박나래, '수해 복구' 기부 행렬 동참",
+                "url": "http://www.sportsworldi.com/newsView/20230717507040",
+                "aid": "4fe09ce07653af20",
+                "image": null,
+                "_id": "649673e740d2947ae427e964"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "김종민, “코요태 리더, 신지가 시켜서 해”",
+                "url": "http://www.sportsworldi.com/newsView/20230716516851",
+                "aid": "1b0822e91754ca29",
+                "image": null,
+                "_id": "649673e740d2947ae427e965"
+            }
+        ],
+        "name": "문화일보"
+    },
+    "9": {
+        "materials": [
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "[단독] 국교위, 전교조 추천 국교위원 '거부'…...",
+                "url": "https://home.ebs.co.kr/ebsnews/menu1/newsAllView/60371726/N?eduNewsYn=N",
+                "aid": "63b436be78a97cbe",
+                "image": {
+                    "url": "https://s.pstatic.net/dthumb.phinf/?src=%22https%3A%2F%2Fs.pstatic.net%2Fstatic%2Fnewsstand%2F2023%2F0717%2Farticle_img%2Fnew_main%2F9076%2F104306_001.png%22&type=nf312_208&service=navermain"
+                },
+                "_id": "643542ba1f0f6898fc2221a4"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "영아 유기·살해 확인 계속…후속 입법 속도",
+                "url": "https://home.ebs.co.kr/ebsnews/menu1/newsAllView/60371727/N?eduNewsYn=N",
+                "aid": "bd8fa0ff6c3900ff",
+                "image": null,
+                "_id": "643542ba1f0f6898fc2221a5"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "<뉴스브릿지> 계약 종료 후 '이름' 잃는 가수들…분쟁 원인과 해결책은",
+                "url": "https://home.ebs.co.kr/ebsnews/menu1/newsAllView/60371728/N?eduNewsYn=N",
+                "aid": "176b0b405fc88540",
+                "image": null,
+                "_id": "643542ba1f0f6898fc2221a6"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "[단독] 반수생 급증 현실화되나…9월 모평 학원 응시생 전년比 1,536명↑",
+                "url": "https://home.ebs.co.kr/ebsnews/menu1/newsAllView/60371690/N?eduNewsYn=N",
+                "aid": "22e2ec50168bd010",
+                "image": null,
+                "_id": "643542ba1f0f6898fc2221a7"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "어린이집‧유치원 대기 인원 한눈에…통합정보 개편",
+                "url": "https://home.ebs.co.kr/ebsnews/menu1/newsAllView/60371691/N?eduNewsYn=N",
+                "aid": "7cbe56910a1b5451",
+                "image": null,
+                "_id": "643542ba1f0f6898fc2221a8"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "영아살해 '솜방망이' 개선…70년만 형법 개정 추진",
+                "url": "https://home.ebs.co.kr/ebsnews/menu1/newsAllView/60371692/N?eduNewsYn=N",
+                "aid": "d699c0d2fdaad892",
+                "image": null,
+                "_id": "643542ba1f0f6898fc2221a9"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "'4세대 나이스' 불편 이어져…안정화 과제는?",
+                "url": "https://home.ebs.co.kr/ebsnews/menu1/newsAllView/60371410/N?eduNewsYn=N",
+                "aid": "75004156ad1216",
+                "image": null,
+                "_id": "64a69d1558a9ce6eb3c6d2e8"
+            }
+        ],
+        "name": "KBS World"
+    },
+    "10": {
+        "materials": [
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "오송 지하차도 교통통제 왜 안했나... 사망자 계속 늘어",
+                "url": "http://www.womennews.co.kr/news/articleView.html?idxno=238458",
+                "aid": "bba8a21b6f082e9b",
+                "image": {
+                    "url": "https://s.pstatic.net/dthumb.phinf/?src=%22https%3A%2F%2Fs.pstatic.net%2Fstatic%2Fnewsstand%2F2023%2F0717%2Farticle_img%2Fnew_main%2F9053%2F111451_001.jpg%22&type=nf312_208&service=navermain"
+                },
+                "_id": "643542ba1f0f6898fc2220af"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "오송 침수 지하차도 사망자 7명…5명은 버스 탑승객",
+                "url": "http://www.womennews.co.kr/news/articleView.html?idxno=238452",
+                "aid": "bba8a215487f4815",
+                "image": null,
+                "_id": "64a084d762e82fd2bec3dfb0"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "윤 대통령, 우크라이나 방문… 젤렌스키와 정상회담",
+                "url": "http://www.womennews.co.kr/news/articleView.html?idxno=238450",
+                "aid": "bba8a21390fc5093",
+                "image": null,
+                "_id": "64a084d762e82fd2bec3dfb1"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "52세에 대학 간 엄마와 페미니스트 딸 : 작가일 인스타툰",
+                "url": "http://www.womennews.co.kr/news/articleView.html?idxno=238264",
+                "aid": "bba89ab4ceb2d7b4",
+                "image": null,
+                "_id": "64a084d762e82fd2bec3dfb2"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "[날씨] 충청권 시간당  30~60mm 폭우...내일까지 최고 300mm 이상",
+                "url": "http://www.womennews.co.kr/news/articleView.html?idxno=238440",
+                "aid": "bba8a1f426ccc874",
+                "image": null,
+                "_id": "64a084d762e82fd2bec3dfb3"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "“대기업 사외이사, ‘법조계 서육남’ 편중… 기업 지배구조 다양성 부족”",
+                "url": "http://www.womennews.co.kr/news/articleView.html?idxno=238394",
+                "aid": "bba89ed25b00e812",
+                "image": null,
+                "_id": "64ae9be1c499cc07f349e0fc"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "“‘불체포특권’ 포기하겠습니다” 민주당 의원 31명 선언",
+                "url": "http://www.womennews.co.kr/news/articleView.html?idxno=238429",
+                "aid": "bba8a1bf0c3b11ff",
+                "image": null,
+                "_id": "64b2dfd57dd28a7aefc56774"
+            }
+        ],
+        "name": "한국중앙데일리"
+    },
+    "11": {
+        "materials": [
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "학교 신설, 특수교육원, 폐교, IB까지 지금 제주도교육청은 온통 ‘용역 중’",
+                "url": "http://www.jejusori.net/news/articleView.html?idxno=417186",
+                "aid": "864950ea3ed26bd6",
+                "image": {
+                    "url": "https://s.pstatic.net/dthumb.phinf/?src=%22https%3A%2F%2Fs.pstatic.net%2Fstatic%2Fnewsstand%2F2023%2F0717%2Farticle_img%2Fnew_main%2F9073%2F104306_001.jpg%22&type=nf312_208&service=navermain"
+                },
+                "_id": "643542ba1f0f6898fc222165"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "“일본 원전 오염수 해양 방류 저지 우리 세대의 무조건적인 의무이자 책임”",
+                "url": "http://www.jejusori.net/news/articleView.html?idxno=417190",
+                "aid": "864951033c1bd8dd",
+                "image": null,
+                "_id": "643542ba1f0f6898fc222166"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "가칭 제주예술인회관, ‘지역에 꼭 필요한 예술공간’ 추진 탄력받을까?",
+                "url": "http://www.jejusori.net/news/articleView.html?idxno=417195",
+                "aid": "86495108b400ec38",
+                "image": null,
+                "_id": "643542ba1f0f6898fc222167"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "취임 1년 오영훈 제주지사-김광수 제주교육감 긍정 평가 ‘동반 하락’",
+                "url": "http://www.jejusori.net/news/articleView.html?idxno=417180",
+                "aid": "864950e4488c549c",
+                "image": null,
+                "_id": "6445133d1f0f6898fc24ddc1"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "“여름 휴가는 푸파페 제주로!” 농촌융복합 체험행사 풍성",
+                "url": "http://www.jejusori.net/news/articleView.html?idxno=417191",
+                "aid": "86495104ba7cdcbc",
+                "image": null,
+                "_id": "6445133d1f0f6898fc24ddc2"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "아픈 몸의 현상학 / 황임경",
+                "url": "http://www.jejusori.net/news/articleView.html?idxno=417201",
+                "aid": "864953aebeafa612",
+                "image": null,
+                "_id": "6445133d1f0f6898fc24ddc3"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "제주 로얄쇼핑 천장 붕괴 원인은?...‘부실공사-시설 노후화’ 의견 분분",
+                "url": "http://www.jejusori.net/news/articleView.html?idxno=416855",
+                "aid": "8648f6743902480c",
+                "image": null,
+                "_id": "6445133d1f0f6898fc24ddc4"
+            }
+        ],
+        "name": "인사이트"
+    },
+    "12": {
+        "materials": [
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "<마당이 있는 집> 원작자 김진영 인터뷰",
+                "url": "https://ch.yes24.com/Article/View/54599?y_contents=채널예스&y_channel=뉴스캐스트&y_area=61",
+                "aid": "7737d4728b170632",
+                "image": {
+                    "url": "https://s.pstatic.net/dthumb.phinf/?src=%22https%3A%2F%2Fs.pstatic.net%2Fstatic%2Fnewsstand%2F2023%2F0717%2Farticle_img%2Fnew_main%2F9084%2F111451_001.jpg%22&type=nf312_208&service=navermain"
+                },
+                "_id": "643542ba1f0f6898fc221ba7"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "What's in my cart? 책 장바구니 특집!",
+                "url": "https://ch.yes24.com/Article/View/54595?y_contents=채널예스&y_channel=뉴스캐스트&y_area=61",
+                "aid": "e232196e2093fc2e",
+                "image": null,
+                "_id": "648049361f0f6898fc301cae"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "삶이 우울하거나 지겨우면 이 작품을 보라!",
+                "url": "https://ch.yes24.com/Article/View/54591?y_contents=채널예스&y_channel=뉴스캐스트&y_area=61",
+                "aid": "4d2c5e6ab610f22a",
+                "image": null,
+                "_id": "64b4a4a660f3c014e7afd1a6"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "뮤지컬 <신의 손가락> - 모두의 인생은 한 편의 동화다",
+                "url": "https://ch.yes24.com/Article/View/54583?y_contents=채널예스&y_channel=뉴스캐스트&y_area=61",
+                "aid": "54c2d28d28660dcd",
+                "image": null,
+                "_id": "64b4a4a660f3c014e7afd1a7"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "예술가들이 매혹된 색채를 찾아 떠나는 프로방스 여행",
+                "url": "https://ch.yes24.com/Article/View/54603?y_contents=채널예스&y_channel=뉴스캐스트&y_area=61",
+                "aid": "d8004a16f6443196",
+                "image": null,
+                "_id": "64b4a4a660f3c014e7afd1a8"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "[김소미의 혼자 영화관에 갔어] 외로운 방조자들의 우주 - <스파이더맨 : 어크로스 더 유니버스>",
+                "url": "https://ch.yes24.com/Article/View/54602?y_contents=채널예스&y_channel=뉴스캐스트&y_area=61",
+                "aid": "f2bedb555ba36f15",
+                "image": null,
+                "_id": "64b4a4a660f3c014e7afd1a9"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "[임진아의 카페 생활] 여름 방학 기분 - 커먼마치",
+                "url": "https://ch.yes24.com/Article/View/54600?y_contents=채널예스&y_channel=뉴스캐스트&y_area=61",
+                "aid": "283bfdd32661ea13",
+                "image": null,
+                "_id": "64b4a4a660f3c014e7afd1aa"
+            }
+        ],
+        "name": "법률방송뉴스"
+    },
+    "13": {
+        "materials": [
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "Heavy Monsoon Rains Leave at Least 39 Dead",
+                "url": "http://world.kbs.co.kr/service/news_view.htm?lang=e&id=Dm&Seq_Code=179159",
+                "aid": "2f121de9023158e9",
+                "image": {
+                    "url": "https://s.pstatic.net/dthumb.phinf/?src=%22https%3A%2F%2Fs.pstatic.net%2Fstatic%2Fnewsstand%2F2023%2F0717%2Farticle_img%2Fnew_main%2F9057%2F105536_001.jpg%22&type=nf312_208&service=navermain"
+                },
+                "_id": "643542ba1f0f6898fc22210a"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "Heavy Rains to Continue in Chungcheong, Southern Regions",
+                "url": "http://world.kbs.co.kr/service/news_view.htm?lang=e&id=Sc&Seq_Code=179161",
+                "aid": "8cfbb1c70df8f847",
+                "image": null,
+                "_id": "643542ba1f0f6898fc22210b"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "Yoon Returns from Trip to Lithuania, Poland, Ukraine",
+                "url": "http://world.kbs.co.kr/service/news_view.htm?lang=e&id=Po&Seq_Code=179160",
+                "aid": "073c7375b4cefa35",
+                "image": null,
+                "_id": "646310e67dd28a7aefb5ecd2"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "韩暴雨导致39人死亡、9人失踪 逾万人紧急避难",
+                "url": "http://world.kbs.co.kr/service/news_view.htm?lang=c&id=Dm&Seq_Code=80012",
+                "aid": "4faf4b34d06dfdcc",
+                "image": null,
+                "_id": "64a52ac333520e07dac01d0b"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "尹锡悦主持召开暴雨有关会议 朝野就指定灾难地区形成共识",
+                "url": "http://world.kbs.co.kr/service/news_view.htm?lang=c&id=Po&Seq_Code=80014",
+                "aid": "dac96f00dc7ce500",
+                "image": null,
+                "_id": "64a52ac333520e07dac01d0c"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "韓国各地で豪雨 40人死亡 9人行方不明",
+                "url": "http://world.kbs.co.kr/service/news_view.htm?lang=j&id=Dm&Seq_Code=85980",
+                "aid": "fd59ce08547d38",
+                "image": null,
+                "_id": "64a52ac333520e07dac01d0d"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "ソウルの人口減少率 全国で最高",
+                "url": "http://world.kbs.co.kr/service/news_view.htm?lang=j&id=Dm&Seq_Code=85985",
+                "aid": "fd59ce0d7d5b1553",
+                "image": null,
+                "_id": "64aba8f758a9ce6eb3c7c619"
+            }
+        ],
+        "name": "시사저널"
+    },
+    "14": {
+        "materials": [
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "Heavy Monsoon Rains Leave at Least 39 Dead",
+                "url": "http://world.kbs.co.kr/service/news_view.htm?lang=e&id=Dm&Seq_Code=179159",
+                "aid": "2f121de9023158e9",
+                "image": {
+                    "url": "https://s.pstatic.net/dthumb.phinf/?src=%22https%3A%2F%2Fs.pstatic.net%2Fstatic%2Fnewsstand%2F2023%2F0717%2Farticle_img%2Fnew_main%2F9057%2F105536_001.jpg%22&type=nf312_208&service=navermain"
+                },
+                "_id": "643542ba1f0f6898fc22210a"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "Heavy Rains to Continue in Chungcheong, Southern Regions",
+                "url": "http://world.kbs.co.kr/service/news_view.htm?lang=e&id=Sc&Seq_Code=179161",
+                "aid": "8cfbb1c70df8f847",
+                "image": null,
+                "_id": "643542ba1f0f6898fc22210b"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "Yoon Returns from Trip to Lithuania, Poland, Ukraine",
+                "url": "http://world.kbs.co.kr/service/news_view.htm?lang=e&id=Po&Seq_Code=179160",
+                "aid": "073c7375b4cefa35",
+                "image": null,
+                "_id": "646310e67dd28a7aefb5ecd2"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "韩暴雨导致39人死亡、9人失踪 逾万人紧急避难",
+                "url": "http://world.kbs.co.kr/service/news_view.htm?lang=c&id=Dm&Seq_Code=80012",
+                "aid": "4faf4b34d06dfdcc",
+                "image": null,
+                "_id": "64a52ac333520e07dac01d0b"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "尹锡悦主持召开暴雨有关会议 朝野就指定灾难地区形成共识",
+                "url": "http://world.kbs.co.kr/service/news_view.htm?lang=c&id=Po&Seq_Code=80014",
+                "aid": "dac96f00dc7ce500",
+                "image": null,
+                "_id": "64a52ac333520e07dac01d0c"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "韓国各地で豪雨 40人死亡 9人行方不明",
+                "url": "http://world.kbs.co.kr/service/news_view.htm?lang=j&id=Dm&Seq_Code=85980",
+                "aid": "fd59ce08547d38",
+                "image": null,
+                "_id": "64a52ac333520e07dac01d0d"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "ソウルの人口減少率 全国で最高",
+                "url": "http://world.kbs.co.kr/service/news_view.htm?lang=j&id=Dm&Seq_Code=85985",
+                "aid": "fd59ce0d7d5b1553",
+                "image": null,
+                "_id": "64aba8f758a9ce6eb3c7c619"
+            }
+        ],
+        "name": "조이뉴스"
+    },
+    "15": {
+        "materials": [
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "제주도, 노후 차집관로 2026년까지 전면 교체",
+                "url": "http://www.jejudomin.co.kr/news/articleView.html?idxno=218066",
+                "aid": "16dfd360b7561820",
+                "image": {
+                    "url": "https://s.pstatic.net/dthumb.phinf/?src=%22https%3A%2F%2Fs.pstatic.net%2Fstatic%2Fnewsstand%2F2023%2F0717%2Farticle_img%2Fnew_main%2F9099%2F111451_001.jpg%22&type=nf312_208&service=navermain"
+                },
+                "_id": "643542ba1f0f6898fc221db4"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "제주도의회, 강경흠 의원 징계 착수…사퇴 요구 잇따라",
+                "url": "http://www.jejudomin.co.kr/news/articleView.html?idxno=218046",
+                "aid": "16dfd322e2f707e2",
+                "image": null,
+                "_id": "64af13a4548a597b72d3604a"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "제주도 ‘공공주도 2.0 풍력 조례’ 의회서 ‘제동’",
+                "url": "http://www.jejudomin.co.kr/news/articleView.html?idxno=218022",
+                "aid": "16dfd2e09f9208a0",
+                "image": null,
+                "_id": "64af13a4548a597b72d3604b"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "제주 자원순환사회 조성 핵심기반시설 본격 가동",
+                "url": "http://www.jejudomin.co.kr/news/articleView.html?idxno=218057",
+                "aid": "16dfd34228e80bc2",
+                "image": null,
+                "_id": "64b02a1363b70c6ebed54bff"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "양파·당근 과잉생산 우려...10% 이상 감축 필요",
+                "url": "http://www.jejudomin.co.kr/news/articleView.html?idxno=218055",
+                "aid": "16dfd34071651440",
+                "image": null,
+                "_id": "64b14b113c50cd9912fcde86"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "제주, 동물등록 8.7% 늘고↑...유기동물 11.8% 감소↓",
+                "url": "http://www.jejudomin.co.kr/news/articleView.html?idxno=218054",
+                "aid": "16dfd33f95a3987f",
+                "image": null,
+                "_id": "64b14b113c50cd9912fcde87"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "제주 마을관광 브랜드 ‘카름스테이’ 3곳 신규 선정",
+                "url": "http://www.jejudomin.co.kr/news/articleView.html?idxno=218045",
+                "aid": "16dfd32107358c21",
+                "image": null,
+                "_id": "64b284a8e82d6f14f22b4cc4"
+            }
+        ],
+        "name": "헤럴드경제"
+    },
+    "16": {
+        "materials": [
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "<마당이 있는 집> 원작자 김진영 인터뷰",
+                "url": "https://ch.yes24.com/Article/View/54599?y_contents=채널예스&y_channel=뉴스캐스트&y_area=61",
+                "aid": "7737d4728b170632",
+                "image": {
+                    "url": "https://s.pstatic.net/dthumb.phinf/?src=%22https%3A%2F%2Fs.pstatic.net%2Fstatic%2Fnewsstand%2F2023%2F0717%2Farticle_img%2Fnew_main%2F9084%2F111451_001.jpg%22&type=nf312_208&service=navermain"
+                },
+                "_id": "643542ba1f0f6898fc221ba7"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "What's in my cart? 책 장바구니 특집!",
+                "url": "https://ch.yes24.com/Article/View/54595?y_contents=채널예스&y_channel=뉴스캐스트&y_area=61",
+                "aid": "e232196e2093fc2e",
+                "image": null,
+                "_id": "648049361f0f6898fc301cae"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "삶이 우울하거나 지겨우면 이 작품을 보라!",
+                "url": "https://ch.yes24.com/Article/View/54591?y_contents=채널예스&y_channel=뉴스캐스트&y_area=61",
+                "aid": "4d2c5e6ab610f22a",
+                "image": null,
+                "_id": "64b4a4a660f3c014e7afd1a6"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "뮤지컬 <신의 손가락> - 모두의 인생은 한 편의 동화다",
+                "url": "https://ch.yes24.com/Article/View/54583?y_contents=채널예스&y_channel=뉴스캐스트&y_area=61",
+                "aid": "54c2d28d28660dcd",
+                "image": null,
+                "_id": "64b4a4a660f3c014e7afd1a7"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "예술가들이 매혹된 색채를 찾아 떠나는 프로방스 여행",
+                "url": "https://ch.yes24.com/Article/View/54603?y_contents=채널예스&y_channel=뉴스캐스트&y_area=61",
+                "aid": "d8004a16f6443196",
+                "image": null,
+                "_id": "64b4a4a660f3c014e7afd1a8"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "[김소미의 혼자 영화관에 갔어] 외로운 방조자들의 우주 - <스파이더맨 : 어크로스 더 유니버스>",
+                "url": "https://ch.yes24.com/Article/View/54602?y_contents=채널예스&y_channel=뉴스캐스트&y_area=61",
+                "aid": "f2bedb555ba36f15",
+                "image": null,
+                "_id": "64b4a4a660f3c014e7afd1a9"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "[임진아의 카페 생활] 여름 방학 기분 - 커먼마치",
+                "url": "https://ch.yes24.com/Article/View/54600?y_contents=채널예스&y_channel=뉴스캐스트&y_area=61",
+                "aid": "283bfdd32661ea13",
+                "image": null,
+                "_id": "64b4a4a660f3c014e7afd1aa"
+            }
+        ],
+        "name": "에너지경제"
+    },
+    "17": {
+        "materials": [
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "해변의 양탄자, 비치타올",
+                "url": "https://www.elle.co.kr/article/79048",
+                "aid": "7bd1cdfaa2f52406",
+                "image": {
+                    "url": "https://s.pstatic.net/dthumb.phinf/?src=%22https%3A%2F%2Fs.pstatic.net%2Fstatic%2Fnewsstand%2F2023%2F0717%2Farticle_img%2Fnew_main%2F9080%2F104113_001.jpg%22&type=nf312_208&service=navermain"
+                },
+                "_id": "643542ba1f0f6898fc221b53"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "패션 디자이너 지나 손의 로스엔젤레스 #집업실",
+                "url": "https://www.elle.co.kr/article/79116",
+                "aid": "7bd1d15c456829a4",
+                "image": null,
+                "_id": "643542ba1f0f6898fc221b54"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "마지막 순간까지 예술과 함께 했던 제인 버킨이 세상을 떠났다",
+                "url": "https://www.elle.co.kr/article/79200",
+                "aid": "7bd1d4f8e386b0c8",
+                "image": null,
+                "_id": "643542ba1f0f6898fc221b55"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "지니(JINI)와 글로벌 메이크업 브랜드 M∙A∙C이 만났다",
+                "url": "https://www.elle.co.kr/article/79189",
+                "aid": "7bd1d23833f8f608",
+                "image": null,
+                "_id": "64952266e9bedeca6226220d"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "김우빈-신민아, 가장 먼저 수해 이웃 돕기 나선 기부 커플",
+                "url": "https://www.elle.co.kr/article/79197",
+                "aid": "7bd1d255b1ceb6cb",
+                "image": null,
+                "_id": "64952266e9bedeca6226220e"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "장마철을 현명하게 이겨낼 채정안의 장마 아이템 7",
+                "url": "https://www.elle.co.kr/article/79196",
+                "aid": "7bd1d254aa6981ac",
+                "image": null,
+                "_id": "64a1c4c40123ecca7c84ff5c"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "‘발리댁’ 가희가 알려주는 발리 여행 Tip",
+                "url": "https://www.elle.co.kr/article/79190",
+                "aid": "7bd1d24e7e0a42f2",
+                "image": null,
+                "_id": "64a323283e93486eac6c92ec"
+            }
+        ],
+        "name": "비즈니스포스트"
+    },
+    "18": {
+        "materials": [
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "\"환상적이었다\" 류현진 KKKKK에 美 호평…'144.5㎞+66구' 다 완벽했다",
+                "url": "https://www.spotvnews.co.kr/news/articleView.html?idxno=620598",
+                "aid": "7a8ee490d539a3f0",
+                "image": {
+                    "url": "https://s.pstatic.net/dthumb.phinf/?src=%22https%3A%2F%2Fs.pstatic.net%2Fstatic%2Fnewsstand%2F2023%2F0717%2Farticle_img%2Fnew_main%2F9200%2F111451_001.jpg%22&type=nf312_208&service=navermain"
+                },
+                "_id": "643542ba1f0f6898fc221b68"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "\"빅리그 복귀 가까워져\"…류현진, '5이닝 5K 1실점' 트리플A에서도 강력했다",
+                "url": "https://www.spotvnews.co.kr/news/articleView.html?idxno=620575",
+                "aid": "7a8ee44f486cb751",
+                "image": null,
+                "_id": "64a7c11b052e097ad98f0e8e"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "'최초·유일 김용희 앞에서 채은성 만루포+문동주 158.7㎞ 쾅!' 나눔 올스타 2년 연속 웃었다…클로저 고우석, 타자 뷰캐넌에 진땀[올스타 게임노트]",
+                "url": "https://www.spotvnews.co.kr/news/articleView.html?idxno=620496",
+                "aid": "7a8ee0cd322e2313",
+                "image": null,
+                "_id": "64a7c11b052e097ad98f0e8f"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "'손가락 부상 후유증' 오타니, 멀티히트에도 5이닝 5실점 '시즌 5패'",
+                "url": "https://www.spotvnews.co.kr/news/articleView.html?idxno=620363",
+                "aid": "7a8edcac5f703294",
+                "image": null,
+                "_id": "64a7c11b052e097ad98f0e90"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "'나 MVP 아니야?' 무관의 뷰캐넌, 호명 안 했는데 시상대 '항의 방문'",
+                "url": "https://www.spotvnews.co.kr/news/articleView.html?idxno=620663",
+                "aid": "7a8ee7ef9dfecaf1",
+                "image": null,
+                "_id": "64a7c11b052e097ad98f0e91"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "손흥민과 얼마나 닮았나…호주 팬들 벽화까지 그리며 프리시즌 반겼다",
+                "url": "https://www.spotvnews.co.kr/news/articleView.html?idxno=620646",
+                "aid": "7a8ee7b4bbc5c88c",
+                "image": null,
+                "_id": "64a7c11b052e097ad98f0e92"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "[윔블던 결산] '빅3 시대' 마침표 찍은 알카라스, 새로운 'GOAT' 가능할까",
+                "url": "https://www.spotvnews.co.kr/news/articleView.html?idxno=620676",
+                "aid": "7a8ee8114f0a3bcf",
+                "image": null,
+                "_id": "64b13f1c58a9ce6eb3c90728"
+            }
+        ],
+        "name": "스코어데일리"
+    },
+    "19": {
+        "materials": [
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "학교 신설, 특수교육원, 폐교, IB까지 지금 제주도교육청은 온통 ‘용역 중’",
+                "url": "http://www.jejusori.net/news/articleView.html?idxno=417186",
+                "aid": "864950ea3ed26bd6",
+                "image": {
+                    "url": "https://s.pstatic.net/dthumb.phinf/?src=%22https%3A%2F%2Fs.pstatic.net%2Fstatic%2Fnewsstand%2F2023%2F0717%2Farticle_img%2Fnew_main%2F9073%2F104306_001.jpg%22&type=nf312_208&service=navermain"
+                },
+                "_id": "643542ba1f0f6898fc222165"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "“일본 원전 오염수 해양 방류 저지 우리 세대의 무조건적인 의무이자 책임”",
+                "url": "http://www.jejusori.net/news/articleView.html?idxno=417190",
+                "aid": "864951033c1bd8dd",
+                "image": null,
+                "_id": "643542ba1f0f6898fc222166"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "가칭 제주예술인회관, ‘지역에 꼭 필요한 예술공간’ 추진 탄력받을까?",
+                "url": "http://www.jejusori.net/news/articleView.html?idxno=417195",
+                "aid": "86495108b400ec38",
+                "image": null,
+                "_id": "643542ba1f0f6898fc222167"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "취임 1년 오영훈 제주지사-김광수 제주교육감 긍정 평가 ‘동반 하락’",
+                "url": "http://www.jejusori.net/news/articleView.html?idxno=417180",
+                "aid": "864950e4488c549c",
+                "image": null,
+                "_id": "6445133d1f0f6898fc24ddc1"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "“여름 휴가는 푸파페 제주로!” 농촌융복합 체험행사 풍성",
+                "url": "http://www.jejusori.net/news/articleView.html?idxno=417191",
+                "aid": "86495104ba7cdcbc",
+                "image": null,
+                "_id": "6445133d1f0f6898fc24ddc2"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "아픈 몸의 현상학 / 황임경",
+                "url": "http://www.jejusori.net/news/articleView.html?idxno=417201",
+                "aid": "864953aebeafa612",
+                "image": null,
+                "_id": "6445133d1f0f6898fc24ddc3"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "제주 로얄쇼핑 천장 붕괴 원인은?...‘부실공사-시설 노후화’ 의견 분분",
+                "url": "http://www.jejusori.net/news/articleView.html?idxno=416855",
+                "aid": "8648f6743902480c",
+                "image": null,
+                "_id": "6445133d1f0f6898fc24ddc4"
+            }
+        ],
+        "name": "KNN"
+    },
+    "20": {
+        "materials": [
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "smartPC사랑 2023 상반기 베스트 하드웨어 어워즈 선정",
+                "url": "https://www.ilovepc.co.kr/news/articleView.html?idxno=47208",
+                "aid": "f1d10d514a4a5c51",
+                "image": {
+                    "url": "https://s.pstatic.net/dthumb.phinf/?src=%22https%3A%2F%2Fs.pstatic.net%2Fstatic%2Fnewsstand%2F2023%2F0713%2Farticle_img%2Fnew_main%2F9087%2F100252_001.jpg%22&type=nf312_208&service=navermain"
+                },
+                "_id": "643542ba1f0f6898fc221bd1"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "가성비 게이밍 그래픽카드, 인텔 아크 A750 알아보기",
+                "url": "https://www.ilovepc.co.kr/news/articleView.html?idxno=47112",
+                "aid": "f1d109a9029f0be9",
+                "image": null,
+                "_id": "643542ba1f0f6898fc221bd2"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "2023년 7월호",
+                "url": "http://www.ilovepc.co.kr",
+                "aid": "167fbf961937deaa",
+                "image": null,
+                "_id": "643542ba1f0f6898fc221bd3"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "시원시원한 디스플레이에 휴대성까지? LG전자 2023 그램16 16ZD90RU-GX56K",
+                "url": "https://www.ilovepc.co.kr/news/articleView.html?idxno=47218",
+                "aid": "f1d10d70c8ab6030",
+                "image": null,
+                "_id": "643542ba1f0f6898fc221bd4"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "[팁] 마이크론 2400 SSD로 에이수스 로그 엘라이(ASUS ROG ALLY) 용량을 간단하게 업그레이드해보자",
+                "url": "https://www.ilovepc.co.kr/news/articleView.html?idxno=47306",
+                "aid": "f1d11110a25af090",
+                "image": null,
+                "_id": "643542ba1f0f6898fc221bd5"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "게이밍도 가능한 초경량 노트북? LG전자 2023 그램17 17Z90R-ED7VK",
+                "url": "https://www.ilovepc.co.kr/news/articleView.html?idxno=47219",
+                "aid": "f1d10d71166ad831",
+                "image": null,
+                "_id": "643542ba1f0f6898fc221bd6"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "UMPC 게임기 '옥조' 배터리 폭발 2번…휴대용 게임기 폭발 사고, 다른 제품도 있었을까?",
+                "url": "https://www.ilovepc.co.kr/news/articleView.html?idxno=47357",
+                "aid": "f1d111ac67ff7bec",
+                "image": null,
+                "_id": "643542ba1f0f6898fc221bd7"
+            }
+        ],
+        "name": "한국헤럴드"
+    },
+    "21": {
+        "materials": [
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "'어둠깔린 오송 지하차도 사고현장'···도보 수색 들어간 구조대 [TF사진관]",
+                "url": "http://news.tf.co.kr/read/photomovie/2030886.htm?from=naver",
+                "aid": "cd08638686bd9146",
+                "image": {
+                    "url": "https://s.pstatic.net/dthumb.phinf/?src=%22https%3A%2F%2Fs.pstatic.net%2Fstatic%2Fnewsstand%2F2023%2F0717%2Farticle_img%2Fnew_main%2F9156%2F111224_001.jpg%22&type=nf312_208&service=navermain"
+                },
+                "_id": "643542ba1f0f6898fc222077"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "[대전환 AI시대⑤] 보이스피싱 막는 '만능 재주꾼'…은행권에 스며든 AI",
+                "url": "http://news.tf.co.kr/read/economy/2030646.htm",
+                "aid": "d24e3d064c990f06",
+                "image": null,
+                "_id": "6490c92040d2947ae426c487"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "[韓日 연대의 섬, 소록도②] 밟힌 이의 흔적 찾기…\"응어리 풀어달라\"",
+                "url": "http://news.tf.co.kr/read/ptoday/2030878.htm",
+                "aid": "3b205a4c8efed334",
+                "image": null,
+                "_id": "6490c92040d2947ae426c488"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "미리 보는 갤럭시 언팩….갤럭시Z플립5·폴드5 스펙·가격 이렇게 나온다",
+                "url": "http://news.tf.co.kr/read/economy/2030576.htm",
+                "aid": "a2868ba2de5ef562",
+                "image": null,
+                "_id": "6490c92040d2947ae426c489"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "유기 조장 vs 영아 생존…여야, '보호출산제' 논쟁",
+                "url": "http://news.tf.co.kr/read/ptoday/2030730.htm",
+                "aid": "fef6008795d2f2d9",
+                "image": null,
+                "_id": "649edbf0530d8014e0f48a4a"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "[강일홍의 클로즈업] 최환희도 답답한 '외할머니vs여동생' 갈등",
+                "url": "http://news.tf.co.kr/read/entertain/2030817.htm",
+                "aid": "bd687a58260d9718",
+                "image": null,
+                "_id": "64b08cc0c499cc07f34a3e16"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "[단독] 'BTS 멤버인 척'…미공개 음원 유출 20대 '집행유예'",
+                "url": "http://news.tf.co.kr/read/national/2030897.htm",
+                "aid": "a320712a1cc61c96",
+                "image": null,
+                "_id": "64b08cc0c499cc07f34a3e17"
+            }
+        ],
+        "name": "MBC"
+    },
+    "22": {
+        "materials": [
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "민주당 개그, 2000년 뒤까지 책임지라고 하지!",
+                "url": "https://www.dailian.co.kr/news/view/1253750/?sc=Naver",
+                "aid": "d6c970665deb0aa6",
+                "image": {
+                    "url": "https://s.pstatic.net/dthumb.phinf/?src=%22https%3A%2F%2Fs.pstatic.net%2Fstatic%2Fnewsstand%2F2023%2F0717%2Farticle_img%2Fnew_main%2F9090%2F111451_001.jpg%22&type=nf312_208&service=navermain"
+                },
+                "_id": "643542ba1f0f6898fc221bfb"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "윤 대통령 \"비통한 마음…특별재난지역 선포 등 정책 모두 동원\"",
+                "url": "https://www.dailian.co.kr/news/view/1253856/?sc=Naver",
+                "aid": "42a8a76dd09ecced",
+                "image": null,
+                "_id": "64aa8f3b40d2947ae42c0399"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "검찰, 박영수의 \"변협회장 선거 자금 문제 될 수 있다\" 메모 확보…측근 변호사들 줄소환",
+                "url": "https://www.dailian.co.kr/news/view/1253766/?sc=Naver",
+                "aid": "5bd7464b94ef488b",
+                "image": null,
+                "_id": "64aa8f3b40d2947ae42c039a"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "탄탄한 성장 기반…수익성·여신건전성 모두 '톱' [우리금융 퀀텀점프①]",
+                "url": "https://www.dailian.co.kr/news/view/1253208/?sc=Naver",
+                "aid": "aee7ab0eeddff20e",
+                "image": null,
+                "_id": "64aa8f3b40d2947ae42c039b"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "\"韓, 4대 방산강국 도약 시 매출·고용 2배 증가…맞춤 수출전략 짜야\"",
+                "url": "https://www.dailian.co.kr/news/view/1253657/?sc=Naver",
+                "aid": "fa874d2ce5341a6c",
+                "image": null,
+                "_id": "64aa8f3b40d2947ae42c039c"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "'최대 채권자' 서울보증, 명지학원 기업회생계획 통과시켰다",
+                "url": "https://www.dailian.co.kr/news/view/1253847/?sc=Naver",
+                "aid": "cfdbb4cf965dc50f",
+                "image": null,
+                "_id": "64aa8f3b40d2947ae42c039d"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "경찰, '오송 지하차도 참사' 전담팀 구성…\"책임 소재 본격 수사\"",
+                "url": "https://www.dailian.co.kr/news/view/1253867/?sc=Naver",
+                "aid": "df3eff8d09f308cd",
+                "image": null,
+                "_id": "64aa8f3b40d2947ae42c039e"
+            }
+        ],
+        "name": "뉴데일리"
+    },
+    "23": {
+        "materials": [
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "역대급 수마 덮친 전북, 2차 피해예방 '초비상'",
+                "url": "https://www.jjan.kr/article/20230716580127",
+                "aid": "bd22ef316cb1442f",
+                "image": {
+                    "url": "https://s.pstatic.net/dthumb.phinf/?src=%22https%3A%2F%2Fs.pstatic.net%2Fstatic%2Fnewsstand%2F2023%2F0717%2Farticle_img%2Fnew_main%2F9066%2F094039_001.jpg%22&type=nf312_208&service=navermain"
+                },
+                "_id": "643542ba1f0f6898fc222181"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "'물바다' 된 전북⋯9개 시·군 424세대 753명 대피중",
+                "url": "https://www.jjan.kr/article/20230717580002",
+                "aid": "f209266eaeb575d2",
+                "image": null,
+                "_id": "643542ba1f0f6898fc222182"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "기록적 폭우 원인은? 기상학자들 \"지구 온난화\"",
+                "url": "https://www.jjan.kr/article/20230715580035",
+                "aid": "883cb04cadb963f4",
+                "image": null,
+                "_id": "643542ba1f0f6898fc222183"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "\"특별재난지역 지정을\" 유례없는 폭우에 지역구로 달려간 정치권",
+                "url": "https://www.jjan.kr/article/20230716580333",
+                "aid": "bd22f6ce6deffe32",
+                "image": null,
+                "_id": "643542ba1f0f6898fc222184"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "한국투자공사 진승호 사장, 전주 이전 거부 발언 파문",
+                "url": "https://www.jjan.kr/article/20230716580316",
+                "aid": "bd22f693305b974d",
+                "image": null,
+                "_id": "643542ba1f0f6898fc222185"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "‘구스타보 결승골’ 전북, 수원FC에 1-0 승리",
+                "url": "https://www.jjan.kr/article/20230716580345",
+                "aid": "bd22f6ef56ff6831",
+                "image": null,
+                "_id": "643542ba1f0f6898fc222186"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "발암물질 석면, 내년이면 전북 학교서 사라진다",
+                "url": "https://www.jjan.kr/article/20230716580088",
+                "aid": "bd22ec2bade13df5",
+                "image": null,
+                "_id": "643542ba1f0f6898fc222187"
+            }
+        ],
+        "name": "국민일보"
+    },
+    "24": {
+        "materials": [
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "[여론조사]  인천시민 46.7% “유정복 시장 잘하고 있다”",
+                "url": "https://www.incheonilbo.com/news/articleView.html?idxno=1203079",
+                "aid": "284d86dd9e09acdd",
+                "image": {
+                    "url": "https://s.pstatic.net/dthumb.phinf/?src=%22https%3A%2F%2Fs.pstatic.net%2Fstatic%2Fnewsstand%2F2023%2F0717%2Farticle_img%2Fnew_main%2F9097%2F112248_001.jpg%22&type=nf312_208&service=navermain"
+                },
+                "_id": "643542ba1f0f6898fc221d9f"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "[여론조사] 김동연 경기지사 지지율 급상승…“잘한다” 57.1%",
+                "url": "https://www.incheonilbo.com/news/articleView.html?idxno=1203082",
+                "aid": "284d86f5a13cbcb5",
+                "image": null,
+                "_id": "64aa5830d509cf07e8701c29"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "[여론조사] 인천시민·경기도민 윤석열 대통령 국정수행 평가",
+                "url": "https://www.incheonilbo.com/news/articleView.html?idxno=1203075",
+                "aid": "284d86d9d8c36ed9",
+                "image": null,
+                "_id": "64ab9b5df04b5ed2c5434f2b"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "[여론조사] 경기도민·인천시민 정당 지지도…민주당·국민의힘, 오차범위 내 '엎치락뒤치락'",
+                "url": "https://www.incheonilbo.com/news/articleView.html?idxno=1203074",
+                "aid": "284d86d8e771df58",
+                "image": null,
+                "_id": "64ab9b5df04b5ed2c5434f2c"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "[여론조사] 내년 총선, 인천시민은 변화 바란다",
+                "url": "https://www.incheonilbo.com/news/articleView.html?idxno=1203077",
+                "aid": "284d86dbbb668ddb",
+                "image": null,
+                "_id": "64ab9b5df04b5ed2c5434f2d"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "[여론조사] 내년 총선, 경기도민은 변화 바란다…지역 국회의원 '물갈이' 원해",
+                "url": "https://www.incheonilbo.com/news/articleView.html?idxno=1203078",
+                "aid": "284d86dcacb81d5c",
+                "image": null,
+                "_id": "64b3d1f51f0f6898fc3a224d"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "[창간 35주년 여론조사] 김동연 경기지사 지지율 급상승 이유…철도망 확충·민생경제 주 요인",
+                "url": "https://www.incheonilbo.com/news/articleView.html?idxno=1203092",
+                "aid": "284d87143daab914",
+                "image": null,
+                "_id": "64b3d1f51f0f6898fc3a224e"
+            }
+        ],
+        "name": "일간스포츠"
+    },
+    "25": {
+        "materials": [
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "'CJ 승계 핵심'은 올리브영?… 이재현의 큰 그림",
+                "url": "https://www.moneys.co.kr/news/mwView.php?no=2023071414520662204&type=4&code=w0405&STAND=ST",
+                "aid": "4274ad77e350c369",
+                "image": {
+                    "url": "https://s.pstatic.net/dthumb.phinf/?src=%22https%3A%2F%2Fs.pstatic.net%2Fstatic%2Fnewsstand%2F2023%2F0717%2Farticle_img%2Fnew_main%2F9159%2F111224_001.jpg%22&type=nf312_208&service=navermain"
+                },
+                "_id": "643542ba1f0f6898fc222085"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "\"대출금리 올라\" 영끌족 비명… 주담대 금리 7% 육박",
+                "url": "https://www.moneys.co.kr/news/mwView.php?no=2023071709462957121&type=4&code=w0202&STAND=SS",
+                "aid": "2cf2ad96429f8f6a",
+                "image": null,
+                "_id": "64a0948c3e93486eac6c1932"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "'납품가 기싸움' 쿠팡, '햇반' 없어도 괜찮다?",
+                "url": "https://www.moneys.co.kr/news/mwView.php?no=2023071708431989095&type=4&code=w0405&STAND=SS",
+                "aid": "3a09765135e320cf",
+                "image": null,
+                "_id": "64aee3d4e82d6f14f22a6395"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "국제선 결항 아시아나, 비상대책 가동… 승객 피해 최소화",
+                "url": "https://www.moneys.co.kr/news/mwView.php?no=2023071710195737812&type=4&code=w0406&STAND=SS",
+                "aid": "0d3da8e06e1e4da0",
+                "image": null,
+                "_id": "64aee3d4e82d6f14f22a6396"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "韓 폭우 피해, 외신도 관심… \"동아시아 기후 위기 직면\"",
+                "url": "https://www.moneys.co.kr/news/mwView.php?no=2023071709153565027&type=4&code=w1604&STAND=SS",
+                "aid": "a791c706c35332fa",
+                "image": null,
+                "_id": "64b17417e9bedeca622c07f6"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "오송 지하차도 참사 현장서 웃은 공무원… \"소름 끼친다\"",
+                "url": "https://www.moneys.co.kr/news/mwView.php?no=2023071709575642600&type=4&code=w1602&STAND=SS",
+                "aid": "225ebaa3d87cf6fd",
+                "image": null,
+                "_id": "64b17417e9bedeca622c07f7"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "\"역시 불사조\"… 주윤발 건강이상설, '가짜뉴스'로 판명",
+                "url": "https://www.moneys.co.kr/news/mwView.php?no=2023071708503414165&type=4&code=w1604&STAND=SS",
+                "aid": "eb438184bf7625bc",
+                "image": null,
+                "_id": "64b17417e9bedeca622c07f8"
+            }
+        ],
+        "name": "ZDNET Korea"
+    },
+    "26": {
+        "materials": [
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "[겜ㅊㅊ] 엑조프라이멀 못지 않은, 공룡 때려잡는 게임 5선",
+                "url": "https://www.gamemeca.com/view.php?gid=1739246",
+                "aid": "fd77bcda2444469a",
+                "image": {
+                    "url": "https://s.pstatic.net/dthumb.phinf/?src=%22https%3A%2F%2Fs.pstatic.net%2Fstatic%2Fnewsstand%2F2023%2F0717%2Farticle_img%2Fnew_main%2F9082%2F110339_001.jpg%22&type=nf312_208&service=navermain"
+                },
+                "_id": "643542ba1f0f6898fc221b61"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "[롤짤] 전자두뇌 피넛",
+                "url": "https://www.gamemeca.com/view.php?gid=1739241",
+                "aid": "fd77bcd5d28cb1d5",
+                "image": null,
+                "_id": "648bf6ed6e592107d2de4286"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "[판례.zip] 게임사 상대 소송에서 유저 승소가 늘고 있다",
+                "url": "https://www.gamemeca.com/view.php?gid=1739182",
+                "aid": "fd77b991dd34ce11",
+                "image": null,
+                "_id": "648bf6ed6e592107d2de4287"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "새 마스코트 등장? 반반의 유치원 4 트레일러 공개",
+                "url": "https://www.gamemeca.com/view.php?gid=1739229",
+                "aid": "fd77bc9f0b92539f",
+                "image": null,
+                "_id": "648bf6ed6e592107d2de4288"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "금강선 디렉터, 향후 업데이트는 엔드 콘텐츠 최우선으로",
+                "url": "https://www.gamemeca.com/view.php?gid=1739227",
+                "aid": "fd77bc9d847c181d",
+                "image": null,
+                "_id": "648bf6ed6e592107d2de4289"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "원신 영문 성우 임금체불, 호요버스 \"녹음 스튜디오가 미지불\"",
+                "url": "https://www.gamemeca.com/view.php?gid=1739221",
+                "aid": "fd77bc97ef396597",
+                "image": null,
+                "_id": "648bf6ed6e592107d2de428a"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "수동조작 하고 싶어지는 SF MMORPG, 아레스",
+                "url": "https://www.gamemeca.com/view.php?gid=1739066",
+                "aid": "fd77b59608845ed6",
+                "image": null,
+                "_id": "648bf6ed6e592107d2de428b"
+            }
+        ],
+        "name": "마이데일리"
+    },
+    "27": {
+        "materials": [
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "제주도, 노후 차집관로 2026년까지 전면 교체",
+                "url": "http://www.jejudomin.co.kr/news/articleView.html?idxno=218066",
+                "aid": "16dfd360b7561820",
+                "image": {
+                    "url": "https://s.pstatic.net/dthumb.phinf/?src=%22https%3A%2F%2Fs.pstatic.net%2Fstatic%2Fnewsstand%2F2023%2F0717%2Farticle_img%2Fnew_main%2F9099%2F111451_001.jpg%22&type=nf312_208&service=navermain"
+                },
+                "_id": "643542ba1f0f6898fc221db4"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "제주도의회, 강경흠 의원 징계 착수…사퇴 요구 잇따라",
+                "url": "http://www.jejudomin.co.kr/news/articleView.html?idxno=218046",
+                "aid": "16dfd322e2f707e2",
+                "image": null,
+                "_id": "64af13a4548a597b72d3604a"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "제주도 ‘공공주도 2.0 풍력 조례’ 의회서 ‘제동’",
+                "url": "http://www.jejudomin.co.kr/news/articleView.html?idxno=218022",
+                "aid": "16dfd2e09f9208a0",
+                "image": null,
+                "_id": "64af13a4548a597b72d3604b"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "제주 자원순환사회 조성 핵심기반시설 본격 가동",
+                "url": "http://www.jejudomin.co.kr/news/articleView.html?idxno=218057",
+                "aid": "16dfd34228e80bc2",
+                "image": null,
+                "_id": "64b02a1363b70c6ebed54bff"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "양파·당근 과잉생산 우려...10% 이상 감축 필요",
+                "url": "http://www.jejudomin.co.kr/news/articleView.html?idxno=218055",
+                "aid": "16dfd34071651440",
+                "image": null,
+                "_id": "64b14b113c50cd9912fcde86"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "제주, 동물등록 8.7% 늘고↑...유기동물 11.8% 감소↓",
+                "url": "http://www.jejudomin.co.kr/news/articleView.html?idxno=218054",
+                "aid": "16dfd33f95a3987f",
+                "image": null,
+                "_id": "64b14b113c50cd9912fcde87"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "제주 마을관광 브랜드 ‘카름스테이’ 3곳 신규 선정",
+                "url": "http://www.jejudomin.co.kr/news/articleView.html?idxno=218045",
+                "aid": "16dfd32107358c21",
+                "image": null,
+                "_id": "64b284a8e82d6f14f22b4cc4"
+            }
+        ],
+        "name": "SBS"
+    },
+    "28": {
+        "materials": [
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "충북 오송 지하차도서 밤사이 추가 수습…13명 사망",
+                "url": "https://www.yonhapnewstv.co.kr/news/MYH20230717002000641",
+                "aid": "2ca7da7022378990",
+                "image": {
+                    "url": "https://s.pstatic.net/dthumb.phinf/?src=%22https%3A%2F%2Fs.pstatic.net%2Fstatic%2Fnewsstand%2F2023%2F0717%2Farticle_img%2Fnew_main%2F9109%2F112248_001.jpg%22&type=nf312_208&service=navermain"
+                },
+                "_id": "643542ba1f0f6898fc2220a1"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "충청이남 1년 강수량 60% 집중…주초에도 물벼락",
+                "url": "https://www.yonhapnewstv.co.kr/news/MYH20230716016400641",
+                "aid": "7aabe5b0597a9cd0",
+                "image": null,
+                "_id": "64a8715ec499cc07f3489dfc"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "위험 감수한 왕복 27시간…\"가치외교 실천\"",
+                "url": "https://www.yonhapnewstv.co.kr/news/MYH20230716016100641",
+                "aid": "758d5bd3e8be81cd",
+                "image": null,
+                "_id": "64a8715ec499cc07f3489dfd"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "여야, 수해 현장 방문…\"재난지역 선포\" 한목소리",
+                "url": "https://www.yonhapnewstv.co.kr/news/MYH20230716015900641",
+                "aid": "4e4de58a142876f6",
+                "image": null,
+                "_id": "64a8715ec499cc07f3489dfe"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "한미일, 동해상 미사일 방어훈련…북 ICBM 대응",
+                "url": "https://www.yonhapnewstv.co.kr/news/MYH20230716017100641",
+                "aid": "aa739714e9f4d4ac",
+                "image": null,
+                "_id": "64ac235223adad7ad2994cdd"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "[기업기상도] 기회 맞아 맑은 기업 vs 극한호우에 젖은 기업",
+                "url": "https://www.yonhapnewstv.co.kr/news/MYH20230715009400641",
+                "aid": "bd33f975a68e8eab",
+                "image": null,
+                "_id": "64ac235223adad7ad2994cde"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "할리우드가 뿔났다…63년만에 작가·배우조합 동반파업",
+                "url": "https://www.yonhapnewstv.co.kr/news/MYH20230716006700641",
+                "aid": "17e942aea0e26292",
+                "image": null,
+                "_id": "64ac235223adad7ad2994cdf"
+            }
+        ],
+        "name": "서울경제"
+    },
+    "29": {
+        "materials": [
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "엔하이픈·보이넥스트도어·카드·폴킴·김재환·이승윤, ‘2023 K 글로벌 하트 드림 어워즈’ 뜬다",
+                "url": "http://www.tvdaily.co.kr/read.php3?aid=16895507701679687010",
+                "aid": "8ea56e7a08f7653a",
+                "image": {
+                    "url": "https://s.pstatic.net/dthumb.phinf/?src=%22https%3A%2F%2Fs.pstatic.net%2Fstatic%2Fnewsstand%2F2023%2F0717%2Farticle_img%2Fnew_main%2F9119%2F112248_001.jpg%22&type=nf312_208&service=navermain"
+                },
+                "_id": "643542ba1f0f6898fc2220d2"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "故 최진실 아들 최환희, 동생 최준희 논란에 대신 고개 숙였다 [이슈&톡]",
+                "url": "http://www.tvdaily.co.kr/read.php3?aid=16894584001679674002",
+                "aid": "ba8dcfbccd8f03fc",
+                "image": null,
+                "_id": "64b0d968052e097ad990e7ab"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "'미임파7' 개봉 첫 주말 120만 명 동원, 압도적 1위 [박스오피스]",
+                "url": "http://www.tvdaily.co.kr/read.php3?aid=16895545961679692008",
+                "aid": "c5e1d4c796ed9707",
+                "image": null,
+                "_id": "64b0d968052e097ad990e7ac"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "김우빈·이찬원, 수해 이재민 위해 1억원 기부",
+                "url": "http://www.tvdaily.co.kr/read.php3?aid=16895449511679679002",
+                "aid": "1ebb70da178696da",
+                "image": null,
+                "_id": "64b0d968052e097ad990e7ad"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "남규리, 하이어랭크 엔터테인먼트 전속계약",
+                "url": "http://www.tvdaily.co.kr/read.php3?aid=16895575591679699002",
+                "aid": "0b65e2fe6f3ea8be",
+                "image": null,
+                "_id": "64b0d968052e097ad990e7ae"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "[TD포토] 블랙핑크 로제 '예쁨이 한가득~'",
+                "url": "http://www.tvdaily.co.kr/read.php3?aid=16893023711679539017",
+                "aid": "a6d26613c2708193",
+                "image": null,
+                "_id": "64b0d968052e097ad990e7af"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "[TD영상] 정일우-박은석, 김병만 '꿈 꾸는 아이'같은 모습에 놀라",
+                "url": "http://www.tvdaily.co.kr/read.php3?aid=16893209111679623003",
+                "aid": "0159f4e4bd4962e4",
+                "image": null,
+                "_id": "64b0d968052e097ad990e7b0"
+            }
+        ],
+        "name": "매일경제"
+    },
+    "30": {
+        "materials": [
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "엄정화·김완선·이효리…화사는 '언니'들이 지킨다",
+                "url": "http://www.sportsworldi.com/newsView/20230717506063",
+                "aid": "4fe028c2cf60f142",
+                "image": {
+                    "url": "https://s.pstatic.net/dthumb.phinf/?src=%22https%3A%2F%2Fs.pstatic.net%2Fstatic%2Fnewsstand%2F2023%2F0717%2Farticle_img%2Fnew_main%2F9120%2F112108_001.jpg%22&type=nf312_208&service=navermain"
+                },
+                "_id": "643542ba1f0f6898fc221e6a"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "노경은·노진혁이 첫 올스타전을 즐기는 법",
+                "url": "http://www.sportsworldi.com/newsView/20230715513661",
+                "aid": "e62083283404d8e8",
+                "image": null,
+                "_id": "649673e740d2947ae427e960"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "넷플 '트렁크', 서현진·공유 캐스팅 확정",
+                "url": "http://www.sportsworldi.com/newsView/20230717506152",
+                "aid": "4fe02c63d1eaeaa3",
+                "image": null,
+                "_id": "649673e740d2947ae427e961"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "'킹더랜드' 이준호♥임윤아, 달빛 입맞춤",
+                "url": "http://www.sportsworldi.com/newsView/20230717505503",
+                "aid": "4fdfc66e7ca52bae",
+                "image": null,
+                "_id": "649673e740d2947ae427e962"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "'통영 배수저' 송지효, 난생 첫 인턴 경험",
+                "url": "http://www.sportsworldi.com/newsView/20230717508633",
+                "aid": "4fe127a9f7eef569",
+                "image": null,
+                "_id": "649673e740d2947ae427e963"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "'미션 임파서블7' 개봉 첫 주 176만…압도적 1위",
+                "url": "http://www.sportsworldi.com/newsView/20230717509028",
+                "aid": "4fe18568d4be4ea8",
+                "image": null,
+                "_id": "649673e740d2947ae427e964"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "주우재, 모델 시절 '전 여친' 한 마디에…",
+                "url": "http://www.sportsworldi.com/newsView/20230717506532",
+                "aid": "4fe03b2974cf99e9",
+                "image": null,
+                "_id": "649673e740d2947ae427e965"
+            }
+        ],
+        "name": "MBN"
+    },
+    "31": {
+        "materials": [
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "[단독] 국교위, 전교조 추천 국교위원 '거부'…...",
+                "url": "https://home.ebs.co.kr/ebsnews/menu1/newsAllView/60371726/N?eduNewsYn=N",
+                "aid": "63b436be78a97cbe",
+                "image": {
+                    "url": "https://s.pstatic.net/dthumb.phinf/?src=%22https%3A%2F%2Fs.pstatic.net%2Fstatic%2Fnewsstand%2F2023%2F0717%2Farticle_img%2Fnew_main%2F9076%2F104306_001.png%22&type=nf312_208&service=navermain"
+                },
+                "_id": "643542ba1f0f6898fc2221a4"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "영아 유기·살해 확인 계속…후속 입법 속도",
+                "url": "https://home.ebs.co.kr/ebsnews/menu1/newsAllView/60371727/N?eduNewsYn=N",
+                "aid": "bd8fa0ff6c3900ff",
+                "image": null,
+                "_id": "643542ba1f0f6898fc2221a5"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "<뉴스브릿지> 계약 종료 후 '이름' 잃는 가수들…분쟁 원인과 해결책은",
+                "url": "https://home.ebs.co.kr/ebsnews/menu1/newsAllView/60371728/N?eduNewsYn=N",
+                "aid": "176b0b405fc88540",
+                "image": null,
+                "_id": "643542ba1f0f6898fc2221a6"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "[단독] 반수생 급증 현실화되나…9월 모평 학원 응시생 전년比 1,536명↑",
+                "url": "https://home.ebs.co.kr/ebsnews/menu1/newsAllView/60371690/N?eduNewsYn=N",
+                "aid": "22e2ec50168bd010",
+                "image": null,
+                "_id": "643542ba1f0f6898fc2221a7"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "어린이집‧유치원 대기 인원 한눈에…통합정보 개편",
+                "url": "https://home.ebs.co.kr/ebsnews/menu1/newsAllView/60371691/N?eduNewsYn=N",
+                "aid": "7cbe56910a1b5451",
+                "image": null,
+                "_id": "643542ba1f0f6898fc2221a8"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "영아살해 '솜방망이' 개선…70년만 형법 개정 추진",
+                "url": "https://home.ebs.co.kr/ebsnews/menu1/newsAllView/60371692/N?eduNewsYn=N",
+                "aid": "d699c0d2fdaad892",
+                "image": null,
+                "_id": "643542ba1f0f6898fc2221a9"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "'4세대 나이스' 불편 이어져…안정화 과제는?",
+                "url": "https://home.ebs.co.kr/ebsnews/menu1/newsAllView/60371410/N?eduNewsYn=N",
+                "aid": "75004156ad1216",
+                "image": null,
+                "_id": "64a69d1558a9ce6eb3c6d2e8"
+            }
+        ],
+        "name": "YTN"
+    },
+    "32": {
+        "materials": [
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "[겜ㅊㅊ] 엑조프라이멀 못지 않은, 공룡 때려잡는 게임 5선",
+                "url": "https://www.gamemeca.com/view.php?gid=1739246",
+                "aid": "fd77bcda2444469a",
+                "image": {
+                    "url": "https://s.pstatic.net/dthumb.phinf/?src=%22https%3A%2F%2Fs.pstatic.net%2Fstatic%2Fnewsstand%2F2023%2F0717%2Farticle_img%2Fnew_main%2F9082%2F110339_001.jpg%22&type=nf312_208&service=navermain"
+                },
+                "_id": "643542ba1f0f6898fc221b61"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "[롤짤] 전자두뇌 피넛",
+                "url": "https://www.gamemeca.com/view.php?gid=1739241",
+                "aid": "fd77bcd5d28cb1d5",
+                "image": null,
+                "_id": "648bf6ed6e592107d2de4286"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "[판례.zip] 게임사 상대 소송에서 유저 승소가 늘고 있다",
+                "url": "https://www.gamemeca.com/view.php?gid=1739182",
+                "aid": "fd77b991dd34ce11",
+                "image": null,
+                "_id": "648bf6ed6e592107d2de4287"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "새 마스코트 등장? 반반의 유치원 4 트레일러 공개",
+                "url": "https://www.gamemeca.com/view.php?gid=1739229",
+                "aid": "fd77bc9f0b92539f",
+                "image": null,
+                "_id": "648bf6ed6e592107d2de4288"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "금강선 디렉터, 향후 업데이트는 엔드 콘텐츠 최우선으로",
+                "url": "https://www.gamemeca.com/view.php?gid=1739227",
+                "aid": "fd77bc9d847c181d",
+                "image": null,
+                "_id": "648bf6ed6e592107d2de4289"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "원신 영문 성우 임금체불, 호요버스 \"녹음 스튜디오가 미지불\"",
+                "url": "https://www.gamemeca.com/view.php?gid=1739221",
+                "aid": "fd77bc97ef396597",
+                "image": null,
+                "_id": "648bf6ed6e592107d2de428a"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "수동조작 하고 싶어지는 SF MMORPG, 아레스",
+                "url": "https://www.gamemeca.com/view.php?gid=1739066",
+                "aid": "fd77b59608845ed6",
+                "image": null,
+                "_id": "648bf6ed6e592107d2de428b"
+            }
+        ],
+        "name": "시사위크"
+    },
+    "33": {
+        "materials": [
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "수출·내수·고용 개선, 경기 둔화 끝 보인다",
+                "url": "https://www.joongang.co.kr/article/25177503?utm_source=navernewsstand&utm_medium=referral&utm_campaign=left1image1_newsstand&utm_content=230715",
+                "aid": "14bb6c68679e5d28",
+                "image": {
+                    "url": "https://s.pstatic.net/dthumb.phinf/?src=%22https%3A%2F%2Fs.pstatic.net%2Fstatic%2Fnewsstand%2F2023%2F0715%2Farticle_img%2Fnew_main%2F9227%2F065457_001.jpg%22&type=nf312_208&service=navermain"
+                },
+                "_id": "643542ba1f0f6898fc221b4c"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "오염수 '가짜 과학'이 국민 혼 빼앗아 괴담으로 번져",
+                "url": "https://www.joongang.co.kr/article/25177453?utm_source=navernewsstand&utm_medium=referral&utm_campaign=left2image1_newsstand&utm_content=230715",
+                "aid": "2f6aeca1cec28e61",
+                "image": null,
+                "_id": "643542ba1f0f6898fc221b4d"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "세계 당구 고수들 K구장의 결투…'롱롱남매' 최다승",
+                "url": "https://www.joongang.co.kr/article/25177456?utm_source=navernewsstand&utm_medium=referral&utm_campaign=left2image2_newsstand&utm_content=230715",
+                "aid": "3b397ac32ccf3743",
+                "image": null,
+                "_id": "643de4cc58a9ce6eb3b2bb20"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "미 긴축·불황에도 일자리 늘어…고용지표 역주행 이유",
+                "url": "https://www.joongang.co.kr/article/25177497?utm_source=navernewsstand&utm_medium=referral&utm_campaign=left2image3_newsstand&utm_content=230715",
+                "aid": "b66a045f72f3339f",
+                "image": null,
+                "_id": "644220ca548a597b72bed489"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "폭포비 피해 속출…2명 사망·1명 실종",
+                "url": "https://www.joongang.co.kr/article/25177494?utm_source=navernewsstand&utm_medium=referral&utm_campaign=left3article1_newsstand&utm_content=230715",
+                "aid": "64706958e11ffa18",
+                "image": null,
+                "_id": "644220ca548a597b72bed48a"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "다음주 '명낙 회동' 손 맞잡을까, 헤어질 결심할까 촉각",
+                "url": "https://www.joongang.co.kr/article/25177454?utm_source=navernewsstand&utm_medium=referral&utm_campaign=left3article2_newsstand&utm_content=230715",
+                "aid": "bf7f317b3cda11bb",
+                "image": null,
+                "_id": "644220ca548a597b72bed48b"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "AI로 감쪽같이 합성…실제와 똑같은 가짜에 눈 뜨고도 당한다",
+                "url": "https://www.joongang.co.kr/article/25177455?utm_source=navernewsstand&utm_medium=referral&utm_campaign=left3article3_newsstand&utm_content=230715",
+                "aid": "03924c5b7f484adb",
+                "image": null,
+                "_id": "644220ca548a597b72bed48c"
+            }
+        ],
+        "name": "세계일보"
+    },
+    "34": {
+        "materials": [
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "Death toll from rains at 40 with 13 killed in flooded tunnel",
+                "url": "https://koreajoongangdaily.joins.com/2023/07/17/national/socialAffairs/osong-underpass-heavy-rain/20230717093506335.html",
+                "aid": "effadea33b4a4f3d",
+                "image": {
+                    "url": "https://s.pstatic.net/dthumb.phinf/?src=%22https%3A%2F%2Fs.pstatic.net%2Fstatic%2Fnewsstand%2F2023%2F0717%2Farticle_img%2Fnew_main%2F9061%2F105218_001.jpg%22&type=nf312_208&service=navermain"
+                },
+                "_id": "643542ba1f0f6898fc222142"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "Yoon orders all-out support to heavy rains",
+                "url": "https://koreajoongangdaily.joins.com/2023/07/17/national/politics/Korea-Yoon-Suk-Yeol-rain/20230717102737010.html",
+                "aid": "f0bfa83495337cf4",
+                "image": null,
+                "_id": "643542ba1f0f6898fc222143"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "Hyundai Motor begins comeback in China",
+                "url": "https://koreajoongangdaily.joins.com/2023/07/15/business/industry/korea-china-ioniq-n/20230715070013188.html",
+                "aid": "057a6fdfb5cfff01",
+                "image": null,
+                "_id": "643542ba1f0f6898fc222144"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "Over 45 people dead, missing across Korea as monsoon season rages",
+                "url": "https://koreajoongangdaily.joins.com/2023/07/16/national/socialAffairs/korea-monsoon-rain/20230716185100715.html",
+                "aid": "36049e19ef4d3a07",
+                "image": null,
+                "_id": "643542ba1f0f6898fc222145"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "Flood waters devastate residents in North Chungcheong",
+                "url": "https://koreajoongangdaily.joins.com/2023/07/16/national/socialAffairs/Osong-underpass-torrential-rain/20230716165509045.html",
+                "aid": "2306d145b483c105",
+                "image": null,
+                "_id": "643542ba1f0f6898fc222146"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "Yoon pledges security, humanitarian and reconstruction aid to Ukraine",
+                "url": "https://koreajoongangdaily.joins.com/2023/07/16/national/diplomacy/Korea-Ukraine-bilateral-summit/20230716152427658.html",
+                "aid": "2657b1bcd528d8c4",
+                "image": null,
+                "_id": "643542ba1f0f6898fc222147"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "[THINK ENGLISH] SSG 랜더스 2군 선수들, 폭행 사건 연루",
+                "url": "https://koreajoongangdaily.joins.com/2023/07/17/sports/Baseball/THINK-ENGLISH-SSG-Landers-physical-abuse/20230717093326353.html",
+                "aid": "31b05a78de3c2e38",
+                "image": null,
+                "_id": "643542ba1f0f6898fc222148"
+            }
+        ],
+        "name": "디지털투데이"
+    },
+    "35": {
+        "materials": [
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "수출·내수·고용 개선, 경기 둔화 끝 보인다",
+                "url": "https://www.joongang.co.kr/article/25177503?utm_source=navernewsstand&utm_medium=referral&utm_campaign=left1image1_newsstand&utm_content=230715",
+                "aid": "14bb6c68679e5d28",
+                "image": {
+                    "url": "https://s.pstatic.net/dthumb.phinf/?src=%22https%3A%2F%2Fs.pstatic.net%2Fstatic%2Fnewsstand%2F2023%2F0715%2Farticle_img%2Fnew_main%2F9227%2F065457_001.jpg%22&type=nf312_208&service=navermain"
+                },
+                "_id": "643542ba1f0f6898fc221b4c"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "오염수 '가짜 과학'이 국민 혼 빼앗아 괴담으로 번져",
+                "url": "https://www.joongang.co.kr/article/25177453?utm_source=navernewsstand&utm_medium=referral&utm_campaign=left2image1_newsstand&utm_content=230715",
+                "aid": "2f6aeca1cec28e61",
+                "image": null,
+                "_id": "643542ba1f0f6898fc221b4d"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "세계 당구 고수들 K구장의 결투…'롱롱남매' 최다승",
+                "url": "https://www.joongang.co.kr/article/25177456?utm_source=navernewsstand&utm_medium=referral&utm_campaign=left2image2_newsstand&utm_content=230715",
+                "aid": "3b397ac32ccf3743",
+                "image": null,
+                "_id": "643de4cc58a9ce6eb3b2bb20"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "미 긴축·불황에도 일자리 늘어…고용지표 역주행 이유",
+                "url": "https://www.joongang.co.kr/article/25177497?utm_source=navernewsstand&utm_medium=referral&utm_campaign=left2image3_newsstand&utm_content=230715",
+                "aid": "b66a045f72f3339f",
+                "image": null,
+                "_id": "644220ca548a597b72bed489"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "폭포비 피해 속출…2명 사망·1명 실종",
+                "url": "https://www.joongang.co.kr/article/25177494?utm_source=navernewsstand&utm_medium=referral&utm_campaign=left3article1_newsstand&utm_content=230715",
+                "aid": "64706958e11ffa18",
+                "image": null,
+                "_id": "644220ca548a597b72bed48a"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "다음주 '명낙 회동' 손 맞잡을까, 헤어질 결심할까 촉각",
+                "url": "https://www.joongang.co.kr/article/25177454?utm_source=navernewsstand&utm_medium=referral&utm_campaign=left3article2_newsstand&utm_content=230715",
+                "aid": "bf7f317b3cda11bb",
+                "image": null,
+                "_id": "644220ca548a597b72bed48b"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "AI로 감쪽같이 합성…실제와 똑같은 가짜에 눈 뜨고도 당한다",
+                "url": "https://www.joongang.co.kr/article/25177455?utm_source=navernewsstand&utm_medium=referral&utm_campaign=left3article3_newsstand&utm_content=230715",
+                "aid": "03924c5b7f484adb",
+                "image": null,
+                "_id": "644220ca548a597b72bed48c"
+            }
+        ],
+        "name": "데이터뉴스"
+    },
+    "36": {
+        "materials": [
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "최대 200㎜ 물폭탄… 침수·산사태 위험지 수백명 긴급 대피",
+                "url": "http://www.knnews.co.kr/news/articleView.php?idxno=1409013",
+                "aid": "bf2851f8824cf908",
+                "image": {
+                    "url": "https://s.pstatic.net/dthumb.phinf/?src=%22https%3A%2F%2Fs.pstatic.net%2Fstatic%2Fnewsstand%2F2023%2F0717%2Farticle_img%2Fnew_main%2F9072%2F110825_001.jpg%22&type=nf312_208&service=navermain"
+                },
+                "_id": "643542ba1f0f6898fc222157"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "도내 침수 취약주택 30% “비용 부담돼 물막이판 설치 안 해”",
+                "url": "http://www.knnews.co.kr/news/articleView.php?idxno=1409021",
+                "aid": "bf285215791a758b",
+                "image": null,
+                "_id": "643542ba1f0f6898fc222158"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "창녕함안보 등 4대강 보 정책 ‘해체’서 ‘존치’로 바뀔 듯",
+                "url": "http://www.knnews.co.kr/news/articleView.php?idxno=1409016",
+                "aid": "bf2851fbfd7004a5",
+                "image": null,
+                "_id": "643542ba1f0f6898fc222159"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "지리산 인근 지자체 ‘케이블카 재추진’ 시끌",
+                "url": "http://www.knnews.co.kr/news/articleView.php?idxno=1409000",
+                "aid": "bf2851d6139a692a",
+                "image": null,
+                "_id": "64713b656e592107d2d9ae55"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "오염수 우려에 손님 줄었는데 장마까지… 어시장 상인 시름",
+                "url": "http://www.knnews.co.kr/news/articleView.php?idxno=1409011",
+                "aid": "bf2851f6858af14a",
+                "image": null,
+                "_id": "64997f72530d8014e0f35b08"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "보건의료노조 총파업 종료… 양산부산대병원은 파업 계속",
+                "url": "http://www.knnews.co.kr/news/articleView.php?idxno=1409018",
+                "aid": "bf2851fdfa320c63",
+                "image": null,
+                "_id": "64997f72530d8014e0f35b09"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "경남도의회 “경남TP 원장 후보 ‘유흥접대 전력’ 있을 수 있는 일”",
+                "url": "http://www.knnews.co.kr/news/articleView.php?idxno=1409022",
+                "aid": "bf285216f77b796a",
+                "image": null,
+                "_id": "64997f72530d8014e0f35b0a"
+            }
+        ],
+        "name": "한국대학신문"
+    },
+    "37": {
+        "materials": [
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "[경인 WIDE] 스토킹은 시작일뿐, 절반이 '추가 범죄' 따라왔다",
+                "url": "http://www.kyeongin.com/main/view.php?key=20230716010002963",
+                "aid": "b4973b5aa6a7a21a",
+                "image": {
+                    "url": "https://s.pstatic.net/dthumb.phinf/?src=%22https%3A%2F%2Fs.pstatic.net%2Fstatic%2Fnewsstand%2F2023%2F0716%2Farticle_img%2Fnew_main%2F9068%2F214135_001.jpg%22&type=nf312_208&service=navermain"
+                },
+                "_id": "643542ba1f0f6898fc22218f"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "[경인 WIDE] 피해자 의사와 무관하게 처벌 가능 '환영'",
+                "url": "http://www.kyeongin.com/main/view.php?key=20230716010002964",
+                "aid": "b4973b5bf4671a1b",
+                "image": null,
+                "_id": "643542ba1f0f6898fc222190"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "송도 R2 토지매매 수의계약 검토… 경제청·iH '특혜 논란' 불보듯",
+                "url": "http://www.kyeongin.com/main/view.php?key=20230714010002876",
+                "aid": "cc04557d184ae3fd",
+                "image": null,
+                "_id": "643542ba1f0f6898fc222191"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "'양평고속도로 백지화' 경기도·국토부 공개토론하나",
+                "url": "http://www.kyeongin.com/main/view.php?key=20230716010003117",
+                "aid": "b497911a5d82bc5a",
+                "image": null,
+                "_id": "643542ba1f0f6898fc222192"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "국내 첫 자율주행 '판타G버스', 오늘부터 판교 도로서 부르릉",
+                "url": "http://www.kyeongin.com/main/view.php?key=20230716010003090",
+                "aid": "b4978e4a3cbf0f0a",
+                "image": null,
+                "_id": "643542ba1f0f6898fc222193"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "주말내내 전국에 쏟아진 물폭탄… 아직, 남았다",
+                "url": "http://www.kyeongin.com/main/view.php?key=20230716010003108",
+                "aid": "b49790fc2ce1307c",
+                "image": null,
+                "_id": "643542ba1f0f6898fc222194"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "[오래된 가게 '이어가게'] 41년 손맛 '부영선지국'",
+                "url": "http://www.kyeongin.com/main/view.php?key=20230714010002870",
+                "aid": "cc04557745ce13f7",
+                "image": null,
+                "_id": "643542ba1f0f6898fc222195"
+            }
+        ],
+        "name": "서울파이낸스"
+    },
+    "38": {
+        "materials": [
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "“음식 많이 담았다고 손님 쫓아낸 한식뷔페, 제가 한번 가봤습니다” (+리얼 후기)",
+                "url": "https://www.wikitree.co.kr/articles/870491",
+                "aid": "652a000743ea3699",
+                "image": {
+                    "url": "https://s.pstatic.net/dthumb.phinf/?src=%22https%3A%2F%2Fs.pstatic.net%2Fstatic%2Fnewsstand%2F2023%2F0717%2Farticle_img%2Fnew_main%2F9157%2F112248_001.jpg%22&type=nf312_208&service=navermain"
+                },
+                "_id": "643542ba1f0f6898fc22208c"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "'인천 아파트 칼부림' 흉기 찔린 30대 여성, 결국 사망… 가해자 정체가 밝혀졌다",
+                "url": "https://www.wikitree.co.kr/articles/870528",
+                "aid": "652a02f65b95258a",
+                "image": null,
+                "_id": "6496996b60f3c014e7a9bccd"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "이혼 후 게시물 모두 삭제…3년 만에 SNS 재개한 여배우, 근황 전했다",
+                "url": "https://www.wikitree.co.kr/articles/870485",
+                "aid": "6529ffecb59a97d4",
+                "image": null,
+                "_id": "64a9659733520e07dac10f3b"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "'오송 지하차도 침수' 희생자가 올린 페이스북 글... 마음이 찢어집니다",
+                "url": "https://www.wikitree.co.kr/articles/870487",
+                "aid": "6529ffee292fdb92",
+                "image": null,
+                "_id": "64a9659733520e07dac10f3c"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "“사람이 죽었는데...” 싸이, 비난 속출한 문제의 '흠뻑쇼' 후기 (내용)",
+                "url": "https://www.wikitree.co.kr/articles/870497",
+                "aid": "652a000d9eaa01d3",
+                "image": null,
+                "_id": "64b0dbfc548a597b72d3cdf3"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "'나는 자연인이다' 출연자, 경북 예천 산사태로 실종…아내는 숨진 채 발견",
+                "url": "https://www.wikitree.co.kr/articles/870449",
+                "aid": "6529ff74c6dc864c",
+                "image": null,
+                "_id": "64b0dbfc548a597b72d3cdf4"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "5월 결혼한 새신랑…'30살' 초등교사, 오송 지하차도 침수사고로 세상 떠났다",
+                "url": "https://www.wikitree.co.kr/articles/870426",
+                "aid": "6529ff332e88542d",
+                "image": null,
+                "_id": "64b0dbfc548a597b72d3cdf5"
+            }
+        ],
+        "name": "엑스포스뉴스"
+    },
+    "39": {
+        "materials": [
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "송지효, 재벌 2세설의 진실 \"부모님은 부모님, 나는 나\"",
+                "url": "https://tenasia.hankyung.com/tv-drama/article/2023071701774?utm_source=naver&utm_medium=naver_newsstandcast&utm_campaign=newsstandcast_naver_all",
+                "aid": "fe81dc38bf74d7c8",
+                "image": {
+                    "url": "https://s.pstatic.net/dthumb.phinf/?src=%22https%3A%2F%2Fs.pstatic.net%2Fstatic%2Fnewsstand%2F2023%2F0717%2Farticle_img%2Fnew_main%2F9051%2F090303_001.jpg%22&type=nf312_208&service=navermain"
+                },
+                "_id": "643542ba1f0f6898fc2220bd"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "이상민, 69억 빚 청산하면 뭐하나…\"자가 아닌 월세\"",
+                "url": "https://tenasia.hankyung.com/tv-drama/article/2023071702374?utm_source=naver&utm_medium=naver_newsstandcast&utm_campaign=newsstandcast_naver_all",
+                "aid": "5e1d45bd85753663",
+                "image": null,
+                "_id": "643542ba1f0f6898fc2220be"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "'공개 열애 2회' 전현무, '연애 전문가'였네…능수능란",
+                "url": "https://tenasia.hankyung.com/tv-drama/article/2023071702744?utm_source=naver&utm_medium=naver_newsstandcast&utm_campaign=newsstandcast_naver_all",
+                "aid": "9bf46d76d8903bca",
+                "image": null,
+                "_id": "643542ba1f0f6898fc2220bf"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "10기 현숙♥영철, 재혼 앞두고 결별설…\"시간 가져\"",
+                "url": "https://tenasia.hankyung.com/topic/article/2023071702814?utm_source=naver&utm_medium=naver_newsstandcast&utm_campaign=newsstandcast_naver_all",
+                "aid": "334c772f047a946f",
+                "image": null,
+                "_id": "643542ba1f0f6898fc2220c0"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "송혜교·아이유→김우빈♥신민아, '때 안가리는' 기부",
+                "url": "https://tenasia.hankyung.com/topic/article/2023071703114?utm_source=naver&utm_medium=naver_newsstandcast&utm_campaign=newsstandcast_naver_all",
+                "aid": "6bd69c17eb15d197",
+                "image": null,
+                "_id": "643542ba1f0f6898fc2220c1"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "이은지 \"택시기사 父, 남친과 외박 여행에 데려다줘\"",
+                "url": "https://tenasia.hankyung.com/tv-drama/article/2023071701784?utm_source=naver&utm_medium=naver_newsstandcast&utm_campaign=newsstandcast_naver_all",
+                "aid": "6d08ed793dd5dba7",
+                "image": null,
+                "_id": "643542ba1f0f6898fc2220c2"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "'김지민♥' 김준호, 철철 흐르는 바람기? '당황'",
+                "url": "https://tenasia.hankyung.com/topic/article/2023071702794?utm_source=naver&utm_medium=naver_newsstandcast&utm_campaign=newsstandcast_naver_all",
+                "aid": "4529ea58d223cd18",
+                "image": null,
+                "_id": "643542ba1f0f6898fc2220c3"
+            }
+        ],
+        "name": "맥스무비"
+    },
+    "40": {
+        "materials": [
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "제주도, 노후 차집관로 2026년까지 전면 교체",
+                "url": "http://www.jejudomin.co.kr/news/articleView.html?idxno=218066",
+                "aid": "16dfd360b7561820",
+                "image": {
+                    "url": "https://s.pstatic.net/dthumb.phinf/?src=%22https%3A%2F%2Fs.pstatic.net%2Fstatic%2Fnewsstand%2F2023%2F0717%2Farticle_img%2Fnew_main%2F9099%2F112920_001.jpg%22&type=nf312_208&service=navermain"
+                },
+                "_id": "643542ba1f0f6898fc221db4"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "제주도의회, 강경흠 의원 징계 착수…사퇴 요구 잇따라",
+                "url": "http://www.jejudomin.co.kr/news/articleView.html?idxno=218046",
+                "aid": "16dfd322e2f707e2",
+                "image": null,
+                "_id": "64af13a4548a597b72d3604a"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "제주도 ‘공공주도 2.0 풍력 조례’ 의회서 ‘제동’",
+                "url": "http://www.jejudomin.co.kr/news/articleView.html?idxno=218022",
+                "aid": "16dfd2e09f9208a0",
+                "image": null,
+                "_id": "64af13a4548a597b72d3604b"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "제주 자원순환사회 조성 핵심기반시설 본격 가동",
+                "url": "http://www.jejudomin.co.kr/news/articleView.html?idxno=218057",
+                "aid": "16dfd34228e80bc2",
+                "image": null,
+                "_id": "64b02a1363b70c6ebed54bff"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "양파·당근 과잉생산 우려...10% 이상 감축 필요",
+                "url": "http://www.jejudomin.co.kr/news/articleView.html?idxno=218055",
+                "aid": "16dfd34071651440",
+                "image": null,
+                "_id": "64b14b113c50cd9912fcde86"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "제주, 동물등록 8.7% 늘고↑...유기동물 11.8% 감소↓",
+                "url": "http://www.jejudomin.co.kr/news/articleView.html?idxno=218054",
+                "aid": "16dfd33f95a3987f",
+                "image": null,
+                "_id": "64b14b113c50cd9912fcde87"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "제주 마을관광 브랜드 ‘카름스테이’ 3곳 신규 선정",
+                "url": "http://www.jejudomin.co.kr/news/articleView.html?idxno=218045",
+                "aid": "16dfd32107358c21",
+                "image": null,
+                "_id": "64b284a8e82d6f14f22b4cc4"
+            }
+        ],
+        "name": "OBS"
+    },
+    "41": {
+        "materials": [
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "[포커스 인터뷰] 동서대학교 디자인대학 석좌교수 이코 밀리오레",
+                "url": "https://www.jungle.co.kr/magazine/205389",
+                "aid": "277300fef522d282",
+                "image": {
+                    "url": "https://s.pstatic.net/dthumb.phinf/?src=%22https%3A%2F%2Fs.pstatic.net%2Fstatic%2Fnewsstand%2F2023%2F0716%2Farticle_img%2Fnew_main%2F9077%2F183358_001.jpeg%22&type=nf312_208&service=navermain"
+                },
+                "_id": "643542ba1f0f6898fc2221ab"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "[전시 포커스] 가평꽃동네 희망의집 다림 작가들의 ‘2023 여름이야기’",
+                "url": "https://www.jungle.co.kr/magazine/205388",
+                "aid": "277300fd3bab44e3",
+                "image": null,
+                "_id": "643542ba1f0f6898fc2221ac"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "[디자인 이슈] 글자의 힘 보여주는 글로벌 타이포그래피 챌린지, ‘타이포그래피 오디세이: 2023 외솔국제타이포그래피 공모전’ ",
+                "url": "https://www.jungle.co.kr/magazine/205379",
+                "aid": "277300df5a821001",
+                "image": null,
+                "_id": "6445205d6e592107d2d0e2b1"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "[포커스 인터뷰] 사회를 위한 디자인 계획하는 (사)한국산업디자이너협회 한경하 회장",
+                "url": "https://www.jungle.co.kr/magazine/205378",
+                "aid": "277300dea10a8262",
+                "image": null,
+                "_id": "6445205d6e592107d2d0e2b2"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "[포커스 인터뷰] 디자인 교육의 새로운 방향 쓴 ‘아이덱’, 최인숙 조직위원장 ",
+                "url": "https://www.jungle.co.kr/magazine/205362",
+                "aid": "277300b9ad9c6e27",
+                "image": null,
+                "_id": "645635d040d2947ae41be558"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "[포커스 인터뷰] ‘공감과 공생’ 추구하는 에피그램 로컬프로젝트 ",
+                "url": "https://www.jungle.co.kr/magazine/205361",
+                "aid": "277300b8f424e088",
+                "image": null,
+                "_id": "645635d040d2947ae41be559"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "[포커스 인터뷰] 디자이너에서 글을 쓰는 작가로, 디자이너 출신 작가 김운기 ",
+                "url": "https://www.jungle.co.kr/magazine/205360",
+                "aid": "277300b73aad52e9",
+                "image": null,
+                "_id": "645635d040d2947ae41be55a"
+            }
+        ],
+        "name": "소년한국일보"
+    },
+    "42": {
+        "materials": [
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "윤 대통령 \"특별재난지역 선포 등 정책 모두 동원\"",
+                "url": "http://www.obsnews.co.kr/news/articleView.html?idxno=1406756",
+                "aid": "20cbda31ed1c2f6f",
+                "image": {
+                    "url": "https://s.pstatic.net/dthumb.phinf/?src=%22https%3A%2F%2Fs.pstatic.net%2Fstatic%2Fnewsstand%2F2023%2F0717%2Farticle_img%2Fnew_main%2F9070%2F104113_001.jpg%22&type=nf312_208&service=navermain"
+                },
+                "_id": "643542ba1f0f6898fc22219d"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "아파트 복도서 흉기 난동…1명 사망·1명 경상",
+                "url": "http://www.obsnews.co.kr/news/articleView.html?idxno=1406750",
+                "aid": "20cbda2b6ffefeb5",
+                "image": null,
+                "_id": "643542ba1f0f6898fc22219e"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "바다에 아내 빠트리고 돌 던져 살해…30대 구속영장",
+                "url": "http://www.obsnews.co.kr/news/articleView.html?idxno=1406758",
+                "aid": "20cbda33c17b3fad",
+                "image": null,
+                "_id": "64868b31c499cc07f341f2da"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "경기도·융기원·경기대·장비업체 '반도체 공유대학'",
+                "url": "http://www.obsnews.co.kr/news/articleView.html?idxno=1406749",
+                "aid": "20cbda15ddeb4fcb",
+                "image": null,
+                "_id": "64868b31c499cc07f341f2db"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "\"호우 사망·실종 48명\"…집계 외 사망자 1명 늘어",
+                "url": "http://www.obsnews.co.kr/news/articleView.html?idxno=1406757",
+                "aid": "20cbda32574bb78e",
+                "image": null,
+                "_id": "64868b31c499cc07f341f2dc"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "코레일, 경강선 세종대왕릉~여주 구간 운행 재개",
+                "url": "http://www.obsnews.co.kr/news/articleView.html?idxno=1406730",
+                "aid": "20cbd9edd4800eb3",
+                "image": null,
+                "_id": "64868b31c499cc07f341f2dd"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "국회 법사위, 오늘 '영아살해·유기 처벌강화법' 처리",
+                "url": "http://www.obsnews.co.kr/news/articleView.html?idxno=1406727",
+                "aid": "20cbd9d56e0d4f8b",
+                "image": null,
+                "_id": "64a67a2a3e93486eac6d4ead"
+            }
+        ],
+        "name": "한국일보"
+    },
+    "43": {
+        "materials": [
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "[경인 WIDE] 스토킹은 시작일뿐, 절반이 '추가 범죄' 따라왔다",
+                "url": "http://www.kyeongin.com/main/view.php?key=20230716010002963",
+                "aid": "b4973b5aa6a7a21a",
+                "image": {
+                    "url": "https://s.pstatic.net/dthumb.phinf/?src=%22https%3A%2F%2Fs.pstatic.net%2Fstatic%2Fnewsstand%2F2023%2F0716%2Farticle_img%2Fnew_main%2F9068%2F214135_001.jpg%22&type=nf312_208&service=navermain"
+                },
+                "_id": "643542ba1f0f6898fc22218f"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "[경인 WIDE] 피해자 의사와 무관하게 처벌 가능 '환영'",
+                "url": "http://www.kyeongin.com/main/view.php?key=20230716010002964",
+                "aid": "b4973b5bf4671a1b",
+                "image": null,
+                "_id": "643542ba1f0f6898fc222190"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "송도 R2 토지매매 수의계약 검토… 경제청·iH '특혜 논란' 불보듯",
+                "url": "http://www.kyeongin.com/main/view.php?key=20230714010002876",
+                "aid": "cc04557d184ae3fd",
+                "image": null,
+                "_id": "643542ba1f0f6898fc222191"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "'양평고속도로 백지화' 경기도·국토부 공개토론하나",
+                "url": "http://www.kyeongin.com/main/view.php?key=20230716010003117",
+                "aid": "b497911a5d82bc5a",
+                "image": null,
+                "_id": "643542ba1f0f6898fc222192"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "국내 첫 자율주행 '판타G버스', 오늘부터 판교 도로서 부르릉",
+                "url": "http://www.kyeongin.com/main/view.php?key=20230716010003090",
+                "aid": "b4978e4a3cbf0f0a",
+                "image": null,
+                "_id": "643542ba1f0f6898fc222193"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "주말내내 전국에 쏟아진 물폭탄… 아직, 남았다",
+                "url": "http://www.kyeongin.com/main/view.php?key=20230716010003108",
+                "aid": "b49790fc2ce1307c",
+                "image": null,
+                "_id": "643542ba1f0f6898fc222194"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "[오래된 가게 '이어가게'] 41년 손맛 '부영선지국'",
+                "url": "http://www.kyeongin.com/main/view.php?key=20230714010002870",
+                "aid": "cc04557745ce13f7",
+                "image": null,
+                "_id": "643542ba1f0f6898fc222195"
+            }
+        ],
+        "name": "Sportal korea"
+    },
+    "44": {
+        "materials": [
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "송지효, 재벌 2세설의 진실 \"부모님은 부모님, 나는 나\"",
+                "url": "https://tenasia.hankyung.com/tv-drama/article/2023071701774?utm_source=naver&utm_medium=naver_newsstandcast&utm_campaign=newsstandcast_naver_all",
+                "aid": "fe81dc38bf74d7c8",
+                "image": {
+                    "url": "https://s.pstatic.net/dthumb.phinf/?src=%22https%3A%2F%2Fs.pstatic.net%2Fstatic%2Fnewsstand%2F2023%2F0717%2Farticle_img%2Fnew_main%2F9051%2F090303_001.jpg%22&type=nf312_208&service=navermain"
+                },
+                "_id": "643542ba1f0f6898fc2220bd"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "이상민, 69억 빚 청산하면 뭐하나…\"자가 아닌 월세\"",
+                "url": "https://tenasia.hankyung.com/tv-drama/article/2023071702374?utm_source=naver&utm_medium=naver_newsstandcast&utm_campaign=newsstandcast_naver_all",
+                "aid": "5e1d45bd85753663",
+                "image": null,
+                "_id": "643542ba1f0f6898fc2220be"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "'공개 열애 2회' 전현무, '연애 전문가'였네…능수능란",
+                "url": "https://tenasia.hankyung.com/tv-drama/article/2023071702744?utm_source=naver&utm_medium=naver_newsstandcast&utm_campaign=newsstandcast_naver_all",
+                "aid": "9bf46d76d8903bca",
+                "image": null,
+                "_id": "643542ba1f0f6898fc2220bf"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "10기 현숙♥영철, 재혼 앞두고 결별설…\"시간 가져\"",
+                "url": "https://tenasia.hankyung.com/topic/article/2023071702814?utm_source=naver&utm_medium=naver_newsstandcast&utm_campaign=newsstandcast_naver_all",
+                "aid": "334c772f047a946f",
+                "image": null,
+                "_id": "643542ba1f0f6898fc2220c0"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "송혜교·아이유→김우빈♥신민아, '때 안가리는' 기부",
+                "url": "https://tenasia.hankyung.com/topic/article/2023071703114?utm_source=naver&utm_medium=naver_newsstandcast&utm_campaign=newsstandcast_naver_all",
+                "aid": "6bd69c17eb15d197",
+                "image": null,
+                "_id": "643542ba1f0f6898fc2220c1"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "이은지 \"택시기사 父, 남친과 외박 여행에 데려다줘\"",
+                "url": "https://tenasia.hankyung.com/tv-drama/article/2023071701784?utm_source=naver&utm_medium=naver_newsstandcast&utm_campaign=newsstandcast_naver_all",
+                "aid": "6d08ed793dd5dba7",
+                "image": null,
+                "_id": "643542ba1f0f6898fc2220c2"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "'김지민♥' 김준호, 철철 흐르는 바람기? '당황'",
+                "url": "https://tenasia.hankyung.com/topic/article/2023071702794?utm_source=naver&utm_medium=naver_newsstandcast&utm_campaign=newsstandcast_naver_all",
+                "aid": "4529ea58d223cd18",
+                "image": null,
+                "_id": "643542ba1f0f6898fc2220c3"
+            }
+        ],
+        "name": "아시아경제"
+    },
+    "45": {
+        "materials": [
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "英 BBC \"日 오염수 방류에 일본 주민들도 불안 느껴\"",
+                "url": "https://www.dongascience.com/news.php?idx=60721",
+                "aid": "7412e17471a2fa34",
+                "image": {
+                    "url": "https://s.pstatic.net/dthumb.phinf/?src=%22https%3A%2F%2Fs.pstatic.net%2Fstatic%2Fnewsstand%2F2023%2F0717%2Farticle_img%2Fnew_main%2F9086%2F091151_001.jpg%22&type=nf312_208&service=navermain"
+                },
+                "_id": "643542ba1f0f6898fc221bbc"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "폭우로 사망 26명, 실종 10명...17일까지 강한 비",
+                "url": "https://www.dongascience.com/news.php?idx=60719",
+                "aid": "7412e15dad9febdd",
+                "image": null,
+                "_id": "643542ba1f0f6898fc221bbd"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "[씨즈더퓨처] 제로슈거의 미래는...'아스파탐' 발암 가능 물질 지정",
+                "url": "https://www.dongascience.com/news.php?idx=60714",
+                "aid": "7412e158eb7a7458",
+                "image": null,
+                "_id": "643542ba1f0f6898fc221bbe"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "[주말N수학] 대구과학고 수학 1등 비결은",
+                "url": "https://www.dongascience.com/news.php?idx=60703",
+                "aid": "7412e13830672878",
+                "image": null,
+                "_id": "643542ba1f0f6898fc221bbf"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "인도, 달 탐사선 '찬드라얀 3호' 발사 성공...내달 23일 달 착륙 예상",
+                "url": "https://www.dongascience.com/news.php?idx=60720",
+                "aid": "7412e173e46848b3",
+                "image": null,
+                "_id": "643542ba1f0f6898fc221bc0"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "체온으로 센서 구동한다...에너지 하베스터 3D프린팅 개발",
+                "url": "https://www.dongascience.com/news.php?idx=60722",
+                "aid": "7412e175feddabb5",
+                "image": null,
+                "_id": "643542ba1f0f6898fc221bc1"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "생성형AI의 시대… '전문가' 인간은 살아남을까",
+                "url": "https://www.dongascience.com/news.php?idx=60677",
+                "aid": "7412de5462b30954",
+                "image": null,
+                "_id": "643542ba1f0f6898fc221bc2"
+            }
+        ],
+        "name": "프레시안"
+    },
+    "46": {
+        "materials": [
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "민주당 개그, 2000년 뒤까지 책임지라고 하지!",
+                "url": "https://www.dailian.co.kr/news/view/1253750/?sc=Naver",
+                "aid": "d6c970665deb0aa6",
+                "image": {
+                    "url": "https://s.pstatic.net/dthumb.phinf/?src=%22https%3A%2F%2Fs.pstatic.net%2Fstatic%2Fnewsstand%2F2023%2F0717%2Farticle_img%2Fnew_main%2F9090%2F112248_001.jpg%22&type=nf312_208&service=navermain"
+                },
+                "_id": "643542ba1f0f6898fc221bfb"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "윤 대통령 \"비통한 마음…특별재난지역 선포 등 정책 모두 동원\"",
+                "url": "https://www.dailian.co.kr/news/view/1253856/?sc=Naver",
+                "aid": "42a8a76dd09ecced",
+                "image": null,
+                "_id": "64aa8f3b40d2947ae42c0399"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "검찰, 박영수의 \"변협회장 선거 자금 문제 될 수 있다\" 메모 확보…측근 변호사들 줄소환",
+                "url": "https://www.dailian.co.kr/news/view/1253766/?sc=Naver",
+                "aid": "5bd7464b94ef488b",
+                "image": null,
+                "_id": "64aa8f3b40d2947ae42c039a"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "탄탄한 성장 기반…수익성·여신건전성 모두 '톱' [우리금융 퀀텀점프①]",
+                "url": "https://www.dailian.co.kr/news/view/1253208/?sc=Naver",
+                "aid": "aee7ab0eeddff20e",
+                "image": null,
+                "_id": "64aa8f3b40d2947ae42c039b"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "\"韓, 4대 방산강국 도약 시 매출·고용 2배 증가…맞춤 수출전략 짜야\"",
+                "url": "https://www.dailian.co.kr/news/view/1253657/?sc=Naver",
+                "aid": "fa874d2ce5341a6c",
+                "image": null,
+                "_id": "64aa8f3b40d2947ae42c039c"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "'최대 채권자' 서울보증, 명지학원 기업회생계획 통과시켰다",
+                "url": "https://www.dailian.co.kr/news/view/1253847/?sc=Naver",
+                "aid": "cfdbb4cf965dc50f",
+                "image": null,
+                "_id": "64aa8f3b40d2947ae42c039d"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "경찰, '오송 지하차도 참사' 전담팀 구성…\"책임 소재 본격 수사\"",
+                "url": "https://www.dailian.co.kr/news/view/1253867/?sc=Naver",
+                "aid": "df3eff8d09f308cd",
+                "image": null,
+                "_id": "64aa8f3b40d2947ae42c039e"
+            }
+        ],
+        "name": "노컷뉴스"
+    },
+    "47": {
+        "materials": [
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "英 BBC \"日 오염수 방류에 일본 주민들도 불안 느껴\"",
+                "url": "https://www.dongascience.com/news.php?idx=60721",
+                "aid": "7412e17471a2fa34",
+                "image": {
+                    "url": "https://s.pstatic.net/dthumb.phinf/?src=%22https%3A%2F%2Fs.pstatic.net%2Fstatic%2Fnewsstand%2F2023%2F0717%2Farticle_img%2Fnew_main%2F9086%2F091151_001.jpg%22&type=nf312_208&service=navermain"
+                },
+                "_id": "643542ba1f0f6898fc221bbc"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "폭우로 사망 26명, 실종 10명...17일까지 강한 비",
+                "url": "https://www.dongascience.com/news.php?idx=60719",
+                "aid": "7412e15dad9febdd",
+                "image": null,
+                "_id": "643542ba1f0f6898fc221bbd"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "[씨즈더퓨처] 제로슈거의 미래는...'아스파탐' 발암 가능 물질 지정",
+                "url": "https://www.dongascience.com/news.php?idx=60714",
+                "aid": "7412e158eb7a7458",
+                "image": null,
+                "_id": "643542ba1f0f6898fc221bbe"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "[주말N수학] 대구과학고 수학 1등 비결은",
+                "url": "https://www.dongascience.com/news.php?idx=60703",
+                "aid": "7412e13830672878",
+                "image": null,
+                "_id": "643542ba1f0f6898fc221bbf"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "인도, 달 탐사선 '찬드라얀 3호' 발사 성공...내달 23일 달 착륙 예상",
+                "url": "https://www.dongascience.com/news.php?idx=60720",
+                "aid": "7412e173e46848b3",
+                "image": null,
+                "_id": "643542ba1f0f6898fc221bc0"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "체온으로 센서 구동한다...에너지 하베스터 3D프린팅 개발",
+                "url": "https://www.dongascience.com/news.php?idx=60722",
+                "aid": "7412e175feddabb5",
+                "image": null,
+                "_id": "643542ba1f0f6898fc221bc1"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "생성형AI의 시대… '전문가' 인간은 살아남을까",
+                "url": "https://www.dongascience.com/news.php?idx=60677",
+                "aid": "7412de5462b30954",
+                "image": null,
+                "_id": "643542ba1f0f6898fc221bc2"
+            }
+        ],
+        "name": "중앙일보"
+    },
+    "48": {
+        "materials": [
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "[경인 WIDE] 스토킹은 시작일뿐, 절반이 '추가 범죄' 따라왔다",
+                "url": "http://www.kyeongin.com/main/view.php?key=20230716010002963",
+                "aid": "b4973b5aa6a7a21a",
+                "image": {
+                    "url": "https://s.pstatic.net/dthumb.phinf/?src=%22https%3A%2F%2Fs.pstatic.net%2Fstatic%2Fnewsstand%2F2023%2F0716%2Farticle_img%2Fnew_main%2F9068%2F214135_001.jpg%22&type=nf312_208&service=navermain"
+                },
+                "_id": "643542ba1f0f6898fc22218f"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "[경인 WIDE] 피해자 의사와 무관하게 처벌 가능 '환영'",
+                "url": "http://www.kyeongin.com/main/view.php?key=20230716010002964",
+                "aid": "b4973b5bf4671a1b",
+                "image": null,
+                "_id": "643542ba1f0f6898fc222190"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "송도 R2 토지매매 수의계약 검토… 경제청·iH '특혜 논란' 불보듯",
+                "url": "http://www.kyeongin.com/main/view.php?key=20230714010002876",
+                "aid": "cc04557d184ae3fd",
+                "image": null,
+                "_id": "643542ba1f0f6898fc222191"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "'양평고속도로 백지화' 경기도·국토부 공개토론하나",
+                "url": "http://www.kyeongin.com/main/view.php?key=20230716010003117",
+                "aid": "b497911a5d82bc5a",
+                "image": null,
+                "_id": "643542ba1f0f6898fc222192"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "국내 첫 자율주행 '판타G버스', 오늘부터 판교 도로서 부르릉",
+                "url": "http://www.kyeongin.com/main/view.php?key=20230716010003090",
+                "aid": "b4978e4a3cbf0f0a",
+                "image": null,
+                "_id": "643542ba1f0f6898fc222193"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "주말내내 전국에 쏟아진 물폭탄… 아직, 남았다",
+                "url": "http://www.kyeongin.com/main/view.php?key=20230716010003108",
+                "aid": "b49790fc2ce1307c",
+                "image": null,
+                "_id": "643542ba1f0f6898fc222194"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "[오래된 가게 '이어가게'] 41년 손맛 '부영선지국'",
+                "url": "http://www.kyeongin.com/main/view.php?key=20230714010002870",
+                "aid": "cc04557745ce13f7",
+                "image": null,
+                "_id": "643542ba1f0f6898fc222195"
+            }
+        ],
+        "name": "서울신문"
+    },
+    "49": {
+        "materials": [
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "윤 대통령 \"특별재난지역 선포 등 정책 모두 동원\"",
+                "url": "http://www.obsnews.co.kr/news/articleView.html?idxno=1406756",
+                "aid": "20cbda31ed1c2f6f",
+                "image": {
+                    "url": "https://s.pstatic.net/dthumb.phinf/?src=%22https%3A%2F%2Fs.pstatic.net%2Fstatic%2Fnewsstand%2F2023%2F0717%2Farticle_img%2Fnew_main%2F9070%2F104113_001.jpg%22&type=nf312_208&service=navermain"
+                },
+                "_id": "643542ba1f0f6898fc22219d"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "아파트 복도서 흉기 난동…1명 사망·1명 경상",
+                "url": "http://www.obsnews.co.kr/news/articleView.html?idxno=1406750",
+                "aid": "20cbda2b6ffefeb5",
+                "image": null,
+                "_id": "643542ba1f0f6898fc22219e"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "바다에 아내 빠트리고 돌 던져 살해…30대 구속영장",
+                "url": "http://www.obsnews.co.kr/news/articleView.html?idxno=1406758",
+                "aid": "20cbda33c17b3fad",
+                "image": null,
+                "_id": "64868b31c499cc07f341f2da"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "경기도·융기원·경기대·장비업체 '반도체 공유대학'",
+                "url": "http://www.obsnews.co.kr/news/articleView.html?idxno=1406749",
+                "aid": "20cbda15ddeb4fcb",
+                "image": null,
+                "_id": "64868b31c499cc07f341f2db"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "\"호우 사망·실종 48명\"…집계 외 사망자 1명 늘어",
+                "url": "http://www.obsnews.co.kr/news/articleView.html?idxno=1406757",
+                "aid": "20cbda32574bb78e",
+                "image": null,
+                "_id": "64868b31c499cc07f341f2dc"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "코레일, 경강선 세종대왕릉~여주 구간 운행 재개",
+                "url": "http://www.obsnews.co.kr/news/articleView.html?idxno=1406730",
+                "aid": "20cbd9edd4800eb3",
+                "image": null,
+                "_id": "64868b31c499cc07f341f2dd"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "국회 법사위, 오늘 '영아살해·유기 처벌강화법' 처리",
+                "url": "http://www.obsnews.co.kr/news/articleView.html?idxno=1406727",
+                "aid": "20cbd9d56e0d4f8b",
+                "image": null,
+                "_id": "64a67a2a3e93486eac6d4ead"
+            }
+        ],
+        "name": "스포츠조선"
+    },
+    "50": {
+        "materials": [
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "[여론조사]  인천시민 46.7% “유정복 시장 잘하고 있다”",
+                "url": "https://www.incheonilbo.com/news/articleView.html?idxno=1203079",
+                "aid": "284d86dd9e09acdd",
+                "image": {
+                    "url": "https://s.pstatic.net/dthumb.phinf/?src=%22https%3A%2F%2Fs.pstatic.net%2Fstatic%2Fnewsstand%2F2023%2F0717%2Farticle_img%2Fnew_main%2F9097%2F112248_001.jpg%22&type=nf312_208&service=navermain"
+                },
+                "_id": "643542ba1f0f6898fc221d9f"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "[여론조사] 김동연 경기지사 지지율 급상승…“잘한다” 57.1%",
+                "url": "https://www.incheonilbo.com/news/articleView.html?idxno=1203082",
+                "aid": "284d86f5a13cbcb5",
+                "image": null,
+                "_id": "64aa5830d509cf07e8701c29"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "[여론조사] 인천시민·경기도민 윤석열 대통령 국정수행 평가",
+                "url": "https://www.incheonilbo.com/news/articleView.html?idxno=1203075",
+                "aid": "284d86d9d8c36ed9",
+                "image": null,
+                "_id": "64ab9b5df04b5ed2c5434f2b"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "[여론조사] 경기도민·인천시민 정당 지지도…민주당·국민의힘, 오차범위 내 '엎치락뒤치락'",
+                "url": "https://www.incheonilbo.com/news/articleView.html?idxno=1203074",
+                "aid": "284d86d8e771df58",
+                "image": null,
+                "_id": "64ab9b5df04b5ed2c5434f2c"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "[여론조사] 내년 총선, 인천시민은 변화 바란다",
+                "url": "https://www.incheonilbo.com/news/articleView.html?idxno=1203077",
+                "aid": "284d86dbbb668ddb",
+                "image": null,
+                "_id": "64ab9b5df04b5ed2c5434f2d"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "[여론조사] 내년 총선, 경기도민은 변화 바란다…지역 국회의원 '물갈이' 원해",
+                "url": "https://www.incheonilbo.com/news/articleView.html?idxno=1203078",
+                "aid": "284d86dcacb81d5c",
+                "image": null,
+                "_id": "64b3d1f51f0f6898fc3a224d"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "[창간 35주년 여론조사] 김동연 경기지사 지지율 급상승 이유…철도망 확충·민생경제 주 요인",
+                "url": "https://www.incheonilbo.com/news/articleView.html?idxno=1203092",
+                "aid": "284d87143daab914",
+                "image": null,
+                "_id": "64b3d1f51f0f6898fc3a224e"
+            }
+        ],
+        "name": "전자신문"
+    },
+    "51": {
+        "materials": [
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "Death toll from rains at 40 with 13 killed in flooded tunnel",
+                "url": "https://koreajoongangdaily.joins.com/2023/07/17/national/socialAffairs/osong-underpass-heavy-rain/20230717093506335.html",
+                "aid": "effadea33b4a4f3d",
+                "image": {
+                    "url": "https://s.pstatic.net/dthumb.phinf/?src=%22https%3A%2F%2Fs.pstatic.net%2Fstatic%2Fnewsstand%2F2023%2F0717%2Farticle_img%2Fnew_main%2F9061%2F105218_001.jpg%22&type=nf312_208&service=navermain"
+                },
+                "_id": "643542ba1f0f6898fc222142"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "Yoon orders all-out support to heavy rains",
+                "url": "https://koreajoongangdaily.joins.com/2023/07/17/national/politics/Korea-Yoon-Suk-Yeol-rain/20230717102737010.html",
+                "aid": "f0bfa83495337cf4",
+                "image": null,
+                "_id": "643542ba1f0f6898fc222143"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "Hyundai Motor begins comeback in China",
+                "url": "https://koreajoongangdaily.joins.com/2023/07/15/business/industry/korea-china-ioniq-n/20230715070013188.html",
+                "aid": "057a6fdfb5cfff01",
+                "image": null,
+                "_id": "643542ba1f0f6898fc222144"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "Over 45 people dead, missing across Korea as monsoon season rages",
+                "url": "https://koreajoongangdaily.joins.com/2023/07/16/national/socialAffairs/korea-monsoon-rain/20230716185100715.html",
+                "aid": "36049e19ef4d3a07",
+                "image": null,
+                "_id": "643542ba1f0f6898fc222145"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "Flood waters devastate residents in North Chungcheong",
+                "url": "https://koreajoongangdaily.joins.com/2023/07/16/national/socialAffairs/Osong-underpass-torrential-rain/20230716165509045.html",
+                "aid": "2306d145b483c105",
+                "image": null,
+                "_id": "643542ba1f0f6898fc222146"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "Yoon pledges security, humanitarian and reconstruction aid to Ukraine",
+                "url": "https://koreajoongangdaily.joins.com/2023/07/16/national/diplomacy/Korea-Ukraine-bilateral-summit/20230716152427658.html",
+                "aid": "2657b1bcd528d8c4",
+                "image": null,
+                "_id": "643542ba1f0f6898fc222147"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "[THINK ENGLISH] SSG 랜더스 2군 선수들, 폭행 사건 연루",
+                "url": "https://koreajoongangdaily.joins.com/2023/07/17/sports/Baseball/THINK-ENGLISH-SSG-Landers-physical-abuse/20230717093326353.html",
+                "aid": "31b05a78de3c2e38",
+                "image": null,
+                "_id": "643542ba1f0f6898fc222148"
+            }
+        ],
+        "name": "한국경제TV"
+    },
+    "52": {
+        "materials": [
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "“음식 많이 담았다고 손님 쫓아낸 한식뷔페, 제가 한번 가봤습니다” (+리얼 후기)",
+                "url": "https://www.wikitree.co.kr/articles/870491",
+                "aid": "652a000743ea3699",
+                "image": {
+                    "url": "https://s.pstatic.net/dthumb.phinf/?src=%22https%3A%2F%2Fs.pstatic.net%2Fstatic%2Fnewsstand%2F2023%2F0717%2Farticle_img%2Fnew_main%2F9157%2F113134_001.jpg%22&type=nf312_208&service=navermain"
+                },
+                "_id": "643542ba1f0f6898fc22208c"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "금수저 맞습니다...런닝맨 송지효 아버지 직업, '이 업체' 대표이사다",
+                "url": "https://www.wikitree.co.kr/articles/870531",
+                "aid": "652a030e3c84deb2",
+                "image": null,
+                "_id": "6496996b60f3c014e7a9bccd"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "'인천 아파트 칼부림' 흉기 찔린 30대 여성, 결국 사망… 가해자 정체가 밝혀졌다",
+                "url": "https://www.wikitree.co.kr/articles/870528",
+                "aid": "652a02f65b95258a",
+                "image": null,
+                "_id": "64a9659733520e07dac10f3b"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "이혼 후 게시물 모두 삭제…3년 만에 SNS 재개한 여배우, 근황 전했다",
+                "url": "https://www.wikitree.co.kr/articles/870485",
+                "aid": "6529ffecb59a97d4",
+                "image": null,
+                "_id": "64a9659733520e07dac10f3c"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "'오송 지하차도 침수' 희생자가 올린 페이스북 글... 마음이 찢어집니다",
+                "url": "https://www.wikitree.co.kr/articles/870487",
+                "aid": "6529ffee292fdb92",
+                "image": null,
+                "_id": "64b0dbfc548a597b72d3cdf3"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "'나는 자연인이다' 출연자, 경북 예천 산사태로 실종…아내는 숨진 채 발견",
+                "url": "https://www.wikitree.co.kr/articles/870449",
+                "aid": "6529ff74c6dc864c",
+                "image": null,
+                "_id": "64b0dbfc548a597b72d3cdf4"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "5월 결혼한 새신랑…'30살' 초등교사, 오송 지하차도 침수사고로 세상 떠났다",
+                "url": "https://www.wikitree.co.kr/articles/870426",
+                "aid": "6529ff332e88542d",
+                "image": null,
+                "_id": "64b0dbfc548a597b72d3cdf5"
+            }
+        ],
+        "name": "BLOTER"
+    },
+    "53": {
+        "materials": [
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "우주 ‘식집사’는 빛 대신 이산화탄소로 식물을 키운다?",
+                "url": "https://www.sciencetimes.co.kr/?news=%ec%9a%b0%ec%a3%bc-%ec%8b%9d%ec%a7%91%ec%82%ac%eb%8a%94-%eb%b9%9b-%eb%8c%80%ec%8b%a0-%ec%9d%b4%ec%82%b0%ed%99%94%ed%83%84%ec%86%8c%eb%a1%9c-%ec%8b%9d%eb%ac%bc%ec%9d%84-%ed%82%a4",
+                "aid": "bda852ce55333fb2",
+                "image": {
+                    "url": "https://s.pstatic.net/dthumb.phinf/?src=%22https%3A%2F%2Fs.pstatic.net%2Fstatic%2Fnewsstand%2F2023%2F0717%2Farticle_img%2Fnew_main%2F9081%2F111451_001.jpg%22&type=nf312_208&service=navermain"
+                },
+                "_id": "643542ba1f0f6898fc221b5a"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "인종 장벽 없앤 인간 ‘판게놈 참조 지도’ 초안 나왔다",
+                "url": "https://www.sciencetimes.co.kr/?news=%ec%9d%b8%ec%a2%85-%ec%9e%a5%eb%b2%bd-%ec%97%86%ec%95%a4-%ec%9d%b8%ea%b0%84-%ed%8c%90%ea%b2%8c%eb%86%88-%ec%b0%b8%ec%a1%b0-%ec%a7%80%eb%8f%84-%ec%b4%88%ec%95%88-%eb%82%98%ec%99%94",
+                "aid": "37625c79b7d50867",
+                "image": null,
+                "_id": "643542ba1f0f6898fc221b5b"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "‘모나리자’의 눈썹, 짙고 두꺼웠을 수도 있다?",
+                "url": "https://www.sciencetimes.co.kr/?news=%eb%aa%a8%eb%82%98%eb%a6%ac%ec%9e%90%ec%9d%98-%eb%88%88%ec%8d%b9-%ec%a7%99%ea%b3%a0-%eb%91%90%ea%ba%bc%ec%9b%a0%ec%9d%84-%ec%88%98%eb%8f%84-%ec%9e%88%eb%8b%a4",
+                "aid": "03b0b4d7a107bdd7",
+                "image": null,
+                "_id": "643542ba1f0f6898fc221b5c"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "제1회 세계 한인 과학기술인 대회 마지막날, 다양한 기조강연과 포럼이 진행되다",
+                "url": "https://www.sciencetimes.co.kr/?news=%ec%a0%9c1%ed%9a%8c-%ec%84%b8%ea%b3%84-%ed%95%9c%ec%9d%b8-%ea%b3%bc%ed%95%99%ea%b8%b0%ec%88%a0%ec%9d%b8-%eb%8c%80%ed%9a%8c-%eb%a7%88%ec%a7%80%eb%a7%89%eb%82%a0-%eb%8b%a4%ec%96%91%ed%95%9c-%ea%b8%b0",
+                "aid": "d31ce9d4f683c76c",
+                "image": null,
+                "_id": "643542ba1f0f6898fc221b5d"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "디지털 헬스케어, 바이오경제 2.0의 핵심으로 도약하나",
+                "url": "https://www.sciencetimes.co.kr/?news=%eb%94%94%ec%a7%80%ed%84%b8-%ed%97%ac%ec%8a%a4%ec%bc%80%ec%96%b4-%eb%b0%94%ec%9d%b4%ec%98%a4%ea%b2%bd%ec%a0%9c-2-0%ec%9d%98-%ed%95%b5%ec%8b%ac%ec%9c%bc%eb%a1%9c-%eb%8f%84%ec%95%bd%ed%95%98%eb%82%98",
+                "aid": "6b7c1fd04d7e58b0",
+                "image": null,
+                "_id": "643542ba1f0f6898fc221b5e"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "“림프관만 20년 넘게 연구한 덕에 150년의 난제 풀었죠”",
+                "url": "https://www.sciencetimes.co.kr/?p=252189",
+                "aid": "38b34093f68134cd",
+                "image": null,
+                "_id": "643542ba1f0f6898fc221b5f"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "로봇 요리사의 ‘특별한 요리 비결’은 유튜브?",
+                "url": "https://www.sciencetimes.co.kr/?p=252189",
+                "aid": "38b34093f68134cd",
+                "image": null,
+                "_id": "643542ba1f0f6898fc221b60"
+            }
+        ],
+        "name": "KBS"
+    },
+    "54": {
+        "materials": [
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "구멍 뚫린 하늘, 경북이 잠겼다",
+                "url": "http://www.kyongbuk.co.kr/news/articleView.html?idxno=2136962",
+                "aid": "6cc1d4ca9885ec8a",
+                "image": {
+                    "url": "https://s.pstatic.net/dthumb.phinf/?src=%22https%3A%2F%2Fs.pstatic.net%2Fstatic%2Fnewsstand%2F2023%2F0717%2Farticle_img%2Fnew_main%2F9067%2F054046_001.jpg%22&type=nf312_208&service=navermain"
+                },
+                "_id": "643542ba1f0f6898fc222188"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "[단독] 대구은행, 9월 시중銀 인가 신청…은행장 직속 전담조직·TF 설치",
+                "url": "http://www.kyongbuk.co.kr/news/articleView.html?idxno=2136964",
+                "aid": "6cc1d4cc5008e40c",
+                "image": null,
+                "_id": "643542ba1f0f6898fc222189"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "\"피할 엄두도 못냈다\"…산사태 취약지역 초토화 '속수무책'",
+                "url": "http://www.kyongbuk.co.kr/news/articleView.html?idxno=2136955",
+                "aid": "6cc1d4aec19ad7ae",
+                "image": null,
+                "_id": "643542ba1f0f6898fc22218a"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "물폭탄 맞은 경북북부내륙에 최대 300㎜ 이상 더 내린다",
+                "url": "http://www.kyongbuk.co.kr/news/articleView.html?idxno=2136960",
+                "aid": "6cc1d4c8e102f508",
+                "image": null,
+                "_id": "643542ba1f0f6898fc22218b"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "[영상] 동빈대교 건설 공정률 28.5%…도심 교통허브·랜드마크 기대",
+                "url": "http://www.kyongbuk.co.kr/news/articleView.html?idxno=2136969",
+                "aid": "6cc1d4d19ad04ed1",
+                "image": null,
+                "_id": "643542ba1f0f6898fc22218c"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "[영상] 동빈대교 건설 공정률 28.5%…도심 교통허브·랜드마크 기대",
+                "url": "http://www.kyongbuk.co.kr/news/articleView.html?idxno=2136969",
+                "aid": "6cc1d4d19ad04ed1",
+                "image": null,
+                "_id": "643542ba1f0f6898fc22218d"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "[르포] 예천군 백석리 산사태 현장 가보니",
+                "url": "http://www.kyongbuk.co.kr/news/articleView.html?idxno=2136951",
+                "aid": "6cc1d4aa5294e8aa",
+                "image": null,
+                "_id": "64a374b9824d90d2cc4097ac"
+            }
+        ],
+        "name": "동아일보"
+    },
+    "55": {
+        "materials": [
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "제주도, 노후 차집관로 2026년까지 전면 교체",
+                "url": "http://www.jejudomin.co.kr/news/articleView.html?idxno=218066",
+                "aid": "16dfd360b7561820",
+                "image": {
+                    "url": "https://s.pstatic.net/dthumb.phinf/?src=%22https%3A%2F%2Fs.pstatic.net%2Fstatic%2Fnewsstand%2F2023%2F0717%2Farticle_img%2Fnew_main%2F9099%2F112920_001.jpg%22&type=nf312_208&service=navermain"
+                },
+                "_id": "643542ba1f0f6898fc221db4"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "제주도의회, 강경흠 의원 징계 착수…사퇴 요구 잇따라",
+                "url": "http://www.jejudomin.co.kr/news/articleView.html?idxno=218046",
+                "aid": "16dfd322e2f707e2",
+                "image": null,
+                "_id": "64af13a4548a597b72d3604a"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "제주도 ‘공공주도 2.0 풍력 조례’ 의회서 ‘제동’",
+                "url": "http://www.jejudomin.co.kr/news/articleView.html?idxno=218022",
+                "aid": "16dfd2e09f9208a0",
+                "image": null,
+                "_id": "64af13a4548a597b72d3604b"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "제주 자원순환사회 조성 핵심기반시설 본격 가동",
+                "url": "http://www.jejudomin.co.kr/news/articleView.html?idxno=218057",
+                "aid": "16dfd34228e80bc2",
+                "image": null,
+                "_id": "64b02a1363b70c6ebed54bff"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "양파·당근 과잉생산 우려...10% 이상 감축 필요",
+                "url": "http://www.jejudomin.co.kr/news/articleView.html?idxno=218055",
+                "aid": "16dfd34071651440",
+                "image": null,
+                "_id": "64b14b113c50cd9912fcde86"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "제주, 동물등록 8.7% 늘고↑...유기동물 11.8% 감소↓",
+                "url": "http://www.jejudomin.co.kr/news/articleView.html?idxno=218054",
+                "aid": "16dfd33f95a3987f",
+                "image": null,
+                "_id": "64b14b113c50cd9912fcde87"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "제주 마을관광 브랜드 ‘카름스테이’ 3곳 신규 선정",
+                "url": "http://www.jejudomin.co.kr/news/articleView.html?idxno=218045",
+                "aid": "16dfd32107358c21",
+                "image": null,
+                "_id": "64b284a8e82d6f14f22b4cc4"
+            }
+        ],
+        "name": "이데일리"
+    },
+    "56": {
+        "materials": [
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "“음식 많이 담았다고 손님 쫓아낸 한식뷔페, 제가 한번 가봤습니다” (+리얼 후기)",
+                "url": "https://www.wikitree.co.kr/articles/870491",
+                "aid": "652a000743ea3699",
+                "image": {
+                    "url": "https://s.pstatic.net/dthumb.phinf/?src=%22https%3A%2F%2Fs.pstatic.net%2Fstatic%2Fnewsstand%2F2023%2F0717%2Farticle_img%2Fnew_main%2F9157%2F113134_001.jpg%22&type=nf312_208&service=navermain"
+                },
+                "_id": "643542ba1f0f6898fc22208c"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "금수저 맞습니다...런닝맨 송지효 아버지 직업, '이 업체' 대표이사다",
+                "url": "https://www.wikitree.co.kr/articles/870531",
+                "aid": "652a030e3c84deb2",
+                "image": null,
+                "_id": "6496996b60f3c014e7a9bccd"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "'인천 아파트 칼부림' 흉기 찔린 30대 여성, 결국 사망… 가해자 정체가 밝혀졌다",
+                "url": "https://www.wikitree.co.kr/articles/870528",
+                "aid": "652a02f65b95258a",
+                "image": null,
+                "_id": "64a9659733520e07dac10f3b"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "이혼 후 게시물 모두 삭제…3년 만에 SNS 재개한 여배우, 근황 전했다",
+                "url": "https://www.wikitree.co.kr/articles/870485",
+                "aid": "6529ffecb59a97d4",
+                "image": null,
+                "_id": "64a9659733520e07dac10f3c"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "'오송 지하차도 침수' 희생자가 올린 페이스북 글... 마음이 찢어집니다",
+                "url": "https://www.wikitree.co.kr/articles/870487",
+                "aid": "6529ffee292fdb92",
+                "image": null,
+                "_id": "64b0dbfc548a597b72d3cdf3"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "'나는 자연인이다' 출연자, 경북 예천 산사태로 실종…아내는 숨진 채 발견",
+                "url": "https://www.wikitree.co.kr/articles/870449",
+                "aid": "6529ff74c6dc864c",
+                "image": null,
+                "_id": "64b0dbfc548a597b72d3cdf4"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "5월 결혼한 새신랑…'30살' 초등교사, 오송 지하차도 침수사고로 세상 떠났다",
+                "url": "https://www.wikitree.co.kr/articles/870426",
+                "aid": "6529ff332e88542d",
+                "image": null,
+                "_id": "64b0dbfc548a597b72d3cdf5"
+            }
+        ],
+        "name": "뉴시스"
+    },
+    "57": {
+        "materials": [
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "'CJ 승계 핵심'은 올리브영?… 이재현의 큰 그림",
+                "url": "https://www.moneys.co.kr/news/mwView.php?no=2023071414520662204&type=4&code=w0405&STAND=ST",
+                "aid": "4274ad77e350c369",
+                "image": {
+                    "url": "https://s.pstatic.net/dthumb.phinf/?src=%22https%3A%2F%2Fs.pstatic.net%2Fstatic%2Fnewsstand%2F2023%2F0717%2Farticle_img%2Fnew_main%2F9159%2F113134_001.jpg%22&type=nf312_208&service=navermain"
+                },
+                "_id": "643542ba1f0f6898fc222085"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "\"대출금리 올라\" 영끌족 비명… 주담대 금리 7% 육박",
+                "url": "https://www.moneys.co.kr/news/mwView.php?no=2023071709462957121&type=4&code=w0202&STAND=SS",
+                "aid": "2cf2ad96429f8f6a",
+                "image": null,
+                "_id": "64a0948c3e93486eac6c1932"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "'납품가 기싸움' 쿠팡, '햇반' 없어도 괜찮다?",
+                "url": "https://www.moneys.co.kr/news/mwView.php?no=2023071708431989095&type=4&code=w0405&STAND=SS",
+                "aid": "3a09765135e320cf",
+                "image": null,
+                "_id": "64aee3d4e82d6f14f22a6395"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "국제선 결항 아시아나, 비상대책 가동… 승객 피해 최소화",
+                "url": "https://www.moneys.co.kr/news/mwView.php?no=2023071710195737812&type=4&code=w0406&STAND=SS",
+                "aid": "0d3da8e06e1e4da0",
+                "image": null,
+                "_id": "64aee3d4e82d6f14f22a6396"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "韓 폭우 피해, 외신도 관심… \"동아시아 기후 위기 직면\"",
+                "url": "https://www.moneys.co.kr/news/mwView.php?no=2023071709153565027&type=4&code=w1604&STAND=SS",
+                "aid": "a791c706c35332fa",
+                "image": null,
+                "_id": "64b17417e9bedeca622c07f6"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "오송 지하차도 참사 현장서 웃은 공무원… \"소름 끼친다\"",
+                "url": "https://www.moneys.co.kr/news/mwView.php?no=2023071709575642600&type=4&code=w1602&STAND=SS",
+                "aid": "225ebaa3d87cf6fd",
+                "image": null,
+                "_id": "64b17417e9bedeca622c07f7"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "\"역시 불사조\"… 주윤발 건강이상설, '가짜뉴스'로 판명",
+                "url": "https://www.moneys.co.kr/news/mwView.php?no=2023071708503414165&type=4&code=w1604&STAND=SS",
+                "aid": "eb438184bf7625bc",
+                "image": null,
+                "_id": "64b17417e9bedeca622c07f8"
+            }
+        ],
+        "name": "한국경제"
+    },
+    "58": {
+        "materials": [
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "'비 폭탄'으로 48명 사망·실종… \"오송 지하차도서 시신 3구 발견\"",
+                "url": "https://www.newdaily.co.kr/site/data/html/2023/07/17/2023071700045.html",
+                "aid": "7afc0839a02ac7f9",
+                "image": {
+                    "url": "https://s.pstatic.net/dthumb.phinf/?src=%22https%3A%2F%2Fs.pstatic.net%2Fstatic%2Fnewsstand%2F2023%2F0717%2Farticle_img%2Fnew_main%2F9058%2F112248_001.jpg%22&type=nf312_208&service=navermain"
+                },
+                "_id": "643542ba1f0f6898fc22211f"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "尹 \"재난피해 지원 신속하게 해달라\"…폴란드서 호우대책 지시",
+                "url": "https://www.newdaily.co.kr/site/data/html/2023/07/16/2023071600031.html",
+                "aid": "c2bbe15c4b25ae5c",
+                "image": null,
+                "_id": "649d4ba160f3c014e7ab04c8"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "與 김기현, 폭우 피해에 귀국 일정 앞당겨… 5박7일 방미 마무리",
+                "url": "https://www.newdaily.co.kr/site/data/html/2023/07/16/2023071600017.html",
+                "aid": "632c7e94928e8514",
+                "image": null,
+                "_id": "649d4ba160f3c014e7ab04c9"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "국민의힘, '폭우 피해' 괴산 방문… \"특별재난지역 선포해야\"",
+                "url": "https://www.newdaily.co.kr/site/data/html/2023/07/16/2023071600029.html",
+                "aid": "9b7c6b137a4fa213",
+                "image": null,
+                "_id": "649ddffd7a6b147b6bf55df0"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "[N-포커스] 최저임금 벼랑끝 싸움… 尹 노동개혁 분수령",
+                "url": "https://biz.newdaily.co.kr/site/data/html/2023/07/15/2023071500016.html",
+                "aid": "fe220a51e498fdd1",
+                "image": null,
+                "_id": "64ada11f3c50cd9912fbe55c"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "다시 불붙은 수신경쟁… 대출금리 인상 부메랑",
+                "url": "https://biz.newdaily.co.kr/site/data/html/2023/07/17/2023071700085.html",
+                "aid": "67c5e2b969dd5579",
+                "image": null,
+                "_id": "64ada11f3c50cd9912fbe55d"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "삼바-롯바 인력 유출 갈등 고조…'불편한 동거' 속 상도 논란도",
+                "url": "https://biz.newdaily.co.kr/site/data/html/2023/07/15/2023071500033.html",
+                "aid": "62cff6f6241045b6",
+                "image": null,
+                "_id": "64ada11f3c50cd9912fbe55e"
+            }
+        ],
+        "name": "시사IN"
+    },
+    "59": {
+        "materials": [
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "[여론조사]  인천시민 46.7% “유정복 시장 잘하고 있다”",
+                "url": "https://www.incheonilbo.com/news/articleView.html?idxno=1203079",
+                "aid": "284d86dd9e09acdd",
+                "image": {
+                    "url": "https://s.pstatic.net/dthumb.phinf/?src=%22https%3A%2F%2Fs.pstatic.net%2Fstatic%2Fnewsstand%2F2023%2F0717%2Farticle_img%2Fnew_main%2F9097%2F112248_001.jpg%22&type=nf312_208&service=navermain"
+                },
+                "_id": "643542ba1f0f6898fc221d9f"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "[여론조사] 김동연 경기지사 지지율 급상승…“잘한다” 57.1%",
+                "url": "https://www.incheonilbo.com/news/articleView.html?idxno=1203082",
+                "aid": "284d86f5a13cbcb5",
+                "image": null,
+                "_id": "64aa5830d509cf07e8701c29"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "[여론조사] 인천시민·경기도민 윤석열 대통령 국정수행 평가",
+                "url": "https://www.incheonilbo.com/news/articleView.html?idxno=1203075",
+                "aid": "284d86d9d8c36ed9",
+                "image": null,
+                "_id": "64ab9b5df04b5ed2c5434f2b"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "[여론조사] 경기도민·인천시민 정당 지지도…민주당·국민의힘, 오차범위 내 '엎치락뒤치락'",
+                "url": "https://www.incheonilbo.com/news/articleView.html?idxno=1203074",
+                "aid": "284d86d8e771df58",
+                "image": null,
+                "_id": "64ab9b5df04b5ed2c5434f2c"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "[여론조사] 내년 총선, 인천시민은 변화 바란다",
+                "url": "https://www.incheonilbo.com/news/articleView.html?idxno=1203077",
+                "aid": "284d86dbbb668ddb",
+                "image": null,
+                "_id": "64ab9b5df04b5ed2c5434f2d"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "[여론조사] 내년 총선, 경기도민은 변화 바란다…지역 국회의원 '물갈이' 원해",
+                "url": "https://www.incheonilbo.com/news/articleView.html?idxno=1203078",
+                "aid": "284d86dcacb81d5c",
+                "image": null,
+                "_id": "64b3d1f51f0f6898fc3a224d"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "[창간 35주년 여론조사] 김동연 경기지사 지지율 급상승 이유…철도망 확충·민생경제 주 요인",
+                "url": "https://www.incheonilbo.com/news/articleView.html?idxno=1203092",
+                "aid": "284d87143daab914",
+                "image": null,
+                "_id": "64b3d1f51f0f6898fc3a224e"
+            }
+        ],
+        "name": "월간산"
+    },
+    "60": {
+        "materials": [
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "기록적 폭우에… 온 나라가 슬픔에 잠겼다",
+                "url": "https://www.cctoday.co.kr/news/articleView.html?idxno=2181333",
+                "aid": "99f490eae26eb2aa",
+                "image": {
+                    "url": "https://s.pstatic.net/dthumb.phinf/?src=%22https%3A%2F%2Fs.pstatic.net%2Fstatic%2Fnewsstand%2F2023%2F0716%2Farticle_img%2Fnew_main%2F9063%2F183124_001.jpg%22&type=nf312_208&service=navermain"
+                },
+                "_id": "643542ba1f0f6898fc222149"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "충남 3곳·세종 국제화특구 지정 충청권 국제화 교육 기틀 마련 기대",
+                "url": "https://www.cctoday.co.kr/news/articleView.html?idxno=2181137",
+                "aid": "99f4896cb5f5b1ac",
+                "image": null,
+                "_id": "643542ba1f0f6898fc22214a"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "손 놓는 보건의료노조 충청지역 의료공백 불가피",
+                "url": "https://www.cctoday.co.kr/news/articleView.html?idxno=2181057",
+                "aid": "99f485e93c9549e9",
+                "image": null,
+                "_id": "643542ba1f0f6898fc22214b"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "‘지방시대위’ 세종서 출범 어디서나 살기 좋은 지방시대 구현",
+                "url": "https://www.cctoday.co.kr/news/articleView.html?idxno=2180970",
+                "aid": "99f4338a4c042c0a",
+                "image": null,
+                "_id": "643542ba1f0f6898fc22214c"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "“제발” 지하차도만 하염없이 바라보는 실종자 가족들",
+                "url": "https://www.cctoday.co.kr/news/articleView.html?idxno=2181319",
+                "aid": "99f490b2349888f2",
+                "image": null,
+                "_id": "643542ba1f0f6898fc22214d"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "집안까지 들이닥친 빗물 \"살림살이 둥둥 떠다녀\"",
+                "url": "https://www.cctoday.co.kr/news/articleView.html?idxno=2181330",
+                "aid": "99f490e74f2a3f67",
+                "image": null,
+                "_id": "643542ba1f0f6898fc22214e"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "여야 지도부, 폭우 피해 입은 충북 방문 복구 지원 약속",
+                "url": "https://www.cctoday.co.kr/news/articleView.html?idxno=2181316",
+                "aid": "99f490afa15415af",
+                "image": null,
+                "_id": "643542ba1f0f6898fc22214f"
+            }
+        ],
+        "name": "독서신문"
+    },
+    "61": {
+        "materials": [
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "‘고리1’ 멈춘 지 6년…해체 시점도 불투명",
+                "url": "http://www.kookje.co.kr/news2011/asp/newsbody.asp?code=0200&key=20230716.99099004808",
+                "aid": "4cc1783739362c29",
+                "image": {
+                    "url": "https://s.pstatic.net/dthumb.phinf/?src=%22https%3A%2F%2Fs.pstatic.net%2Fstatic%2Fnewsstand%2F2023%2F0717%2Farticle_img%2Fnew_main%2F9071%2F091151_001.jpg%22&type=nf312_208&service=navermain"
+                },
+                "_id": "643542ba1f0f6898fc222150"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "오송지하차도 참사 부산 초량 닮은꼴…홍수경보에도 교통통제 안해",
+                "url": "http://www.kookje.co.kr/news2011/asp/newsbody.asp?code=0300&key=20230716.99001004885",
+                "aid": "ef7612aca9dbac54",
+                "image": null,
+                "_id": "643542ba1f0f6898fc222151"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "윤 대통령 “우크라 평화연대 이니셔티브 추진”",
+                "url": "http://www.kookje.co.kr/news2011/asp/newsbody.asp?code=0100&key=20230717.33001004863",
+                "aid": "c54232ef23404df1",
+                "image": null,
+                "_id": "643542ba1f0f6898fc222152"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "“엑스포 유치 실패하더라도 가덕 신공항 건설을 그대로 추진”",
+                "url": "http://www.kookje.co.kr/news2011/asp/newsbody.asp?code=0200&key=20230716.99099004797",
+                "aid": "4cc1758cd0302734",
+                "image": null,
+                "_id": "64530bd61f0f6898fc278cb4"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "부산대병원 독자 파업 지속 “비정규직 직접고용 결단하라”",
+                "url": "http://www.kookje.co.kr/news2011/asp/newsbody.asp?code=0300&key=20230717.22002004928",
+                "aid": "529c5c5869e24368",
+                "image": null,
+                "_id": "64ad7df27a6b147b6bf89731"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "빅데이터 모으고, 골목여론 듣고…여야 총선모드 ‘ON’",
+                "url": "http://www.kookje.co.kr/news2011/asp/newsbody.asp?code=0100&key=20230717.22005004711",
+                "aid": "0facf7b5256d656b",
+                "image": null,
+                "_id": "64ad7df27a6b147b6bf89732"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "우주항공청법도, 보호출산제도…여야 대치에 법안 처리 ‘하세월’",
+                "url": "http://www.kookje.co.kr/news2011/asp/newsbody.asp?code=0100&key=20230717.22005004785",
+                "aid": "0facf892646734ee",
+                "image": null,
+                "_id": "64ad7df27a6b147b6bf89733"
+            }
+        ],
+        "name": "이코노타임즈"
+    },
+    "62": {
+        "materials": [
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "'미우새' 이은지 \"택시기사父, 남친과 차 태워주며 12만원 받아\"",
+                "url": "https://ent.sbs.co.kr/news/article.do?article_id=E10010273915&plink=STAND&cooper=NAVERMAIN",
+                "aid": "26578a954cd4a94b",
+                "image": {
+                    "url": "https://s.pstatic.net/dthumb.phinf/?src=%22https%3A%2F%2Fs.pstatic.net%2Fstatic%2Fnewsstand%2F2023%2F0717%2Farticle_img%2Fnew_main%2F9154%2F113134_001.jpg%22&type=nf312_208&service=navermain"
+                },
+                "_id": "643542ba1f0f6898fc22207e"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "신민아♥김우빈, 수해 이재민 위해 각 1억원 씩 기부",
+                "url": "https://ent.sbs.co.kr/news/article.do?article_id=E10010273904&plink=STAND&cooper=NAVERMAIN",
+                "aid": "10c216b506e3a56b",
+                "image": null,
+                "_id": "64a5b42158a9ce6eb3c6a2b9"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "'미션 임파서블7', 개봉 첫 주말 1위…누적 관객 176만 돌파",
+                "url": "https://ent.sbs.co.kr/news/article.do?article_id=E10010273913&plink=STAND&cooper=NAVERMAIN",
+                "aid": "24fe33579551b1c9",
+                "image": null,
+                "_id": "64b192c863b70c6ebed5aefd"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "'런닝맨' 송지효, \"부모님 통영서 여객선 사업中…부모님은 부모님, 나는 나\" 13년 만에 첫 고백",
+                "url": "https://ent.sbs.co.kr/news/article.do?article_id=E10010273897&plink=STAND&cooper=NAVERMAIN",
+                "aid": "46c6e3fc081469c4",
+                "image": null,
+                "_id": "64b4912f57629c14fd0b95dc"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "아이브 장원영, '여름 여신'의 독보적 청량미",
+                "url": "https://ent.sbs.co.kr/news/article.do?article_id=E10010272499&plink=STAND&cooper=NAVERMAIN",
+                "aid": "a9877fbd0a387d63",
+                "image": null,
+                "_id": "64b4912f57629c14fd0b95dd"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "'미션7', 역대 최고는 아니지만 시리즈의 정수를 담다",
+                "url": "https://ent.sbs.co.kr/news/article.do?article_id=E10010273757&plink=STAND&cooper=NAVERMAIN",
+                "aid": "6af383191196d147",
+                "image": null,
+                "_id": "64b4912f57629c14fd0b95de"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "돌아온 김선호 \"연기가 늘었으면 좋겠다\"",
+                "url": "https://ent.sbs.co.kr/news/article.do?article_id=E10010273480&plink=STAND&cooper=NAVERMAIN",
+                "aid": "0c646ae6649c9f5a",
+                "image": null,
+                "_id": "64b4912f57629c14fd0b95df"
+            }
+        ],
+        "name": "TJB대전방송"
+    },
+    "63": {
+        "materials": [
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "우주 ‘식집사’는 빛 대신 이산화탄소로 식물을 키운다?",
+                "url": "https://www.sciencetimes.co.kr/?news=%ec%9a%b0%ec%a3%bc-%ec%8b%9d%ec%a7%91%ec%82%ac%eb%8a%94-%eb%b9%9b-%eb%8c%80%ec%8b%a0-%ec%9d%b4%ec%82%b0%ed%99%94%ed%83%84%ec%86%8c%eb%a1%9c-%ec%8b%9d%eb%ac%bc%ec%9d%84-%ed%82%a4",
+                "aid": "bda852ce55333fb2",
+                "image": {
+                    "url": "https://s.pstatic.net/dthumb.phinf/?src=%22https%3A%2F%2Fs.pstatic.net%2Fstatic%2Fnewsstand%2F2023%2F0717%2Farticle_img%2Fnew_main%2F9081%2F111451_001.jpg%22&type=nf312_208&service=navermain"
+                },
+                "_id": "643542ba1f0f6898fc221b5a"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "인종 장벽 없앤 인간 ‘판게놈 참조 지도’ 초안 나왔다",
+                "url": "https://www.sciencetimes.co.kr/?news=%ec%9d%b8%ec%a2%85-%ec%9e%a5%eb%b2%bd-%ec%97%86%ec%95%a4-%ec%9d%b8%ea%b0%84-%ed%8c%90%ea%b2%8c%eb%86%88-%ec%b0%b8%ec%a1%b0-%ec%a7%80%eb%8f%84-%ec%b4%88%ec%95%88-%eb%82%98%ec%99%94",
+                "aid": "37625c79b7d50867",
+                "image": null,
+                "_id": "643542ba1f0f6898fc221b5b"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "‘모나리자’의 눈썹, 짙고 두꺼웠을 수도 있다?",
+                "url": "https://www.sciencetimes.co.kr/?news=%eb%aa%a8%eb%82%98%eb%a6%ac%ec%9e%90%ec%9d%98-%eb%88%88%ec%8d%b9-%ec%a7%99%ea%b3%a0-%eb%91%90%ea%ba%bc%ec%9b%a0%ec%9d%84-%ec%88%98%eb%8f%84-%ec%9e%88%eb%8b%a4",
+                "aid": "03b0b4d7a107bdd7",
+                "image": null,
+                "_id": "643542ba1f0f6898fc221b5c"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "제1회 세계 한인 과학기술인 대회 마지막날, 다양한 기조강연과 포럼이 진행되다",
+                "url": "https://www.sciencetimes.co.kr/?news=%ec%a0%9c1%ed%9a%8c-%ec%84%b8%ea%b3%84-%ed%95%9c%ec%9d%b8-%ea%b3%bc%ed%95%99%ea%b8%b0%ec%88%a0%ec%9d%b8-%eb%8c%80%ed%9a%8c-%eb%a7%88%ec%a7%80%eb%a7%89%eb%82%a0-%eb%8b%a4%ec%96%91%ed%95%9c-%ea%b8%b0",
+                "aid": "d31ce9d4f683c76c",
+                "image": null,
+                "_id": "643542ba1f0f6898fc221b5d"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "디지털 헬스케어, 바이오경제 2.0의 핵심으로 도약하나",
+                "url": "https://www.sciencetimes.co.kr/?news=%eb%94%94%ec%a7%80%ed%84%b8-%ed%97%ac%ec%8a%a4%ec%bc%80%ec%96%b4-%eb%b0%94%ec%9d%b4%ec%98%a4%ea%b2%bd%ec%a0%9c-2-0%ec%9d%98-%ed%95%b5%ec%8b%ac%ec%9c%bc%eb%a1%9c-%eb%8f%84%ec%95%bd%ed%95%98%eb%82%98",
+                "aid": "6b7c1fd04d7e58b0",
+                "image": null,
+                "_id": "643542ba1f0f6898fc221b5e"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "“림프관만 20년 넘게 연구한 덕에 150년의 난제 풀었죠”",
+                "url": "https://www.sciencetimes.co.kr/?p=252189",
+                "aid": "38b34093f68134cd",
+                "image": null,
+                "_id": "643542ba1f0f6898fc221b5f"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "로봇 요리사의 ‘특별한 요리 비결’은 유튜브?",
+                "url": "https://www.sciencetimes.co.kr/?p=252189",
+                "aid": "38b34093f68134cd",
+                "image": null,
+                "_id": "643542ba1f0f6898fc221b60"
+            }
+        ],
+        "name": "시사오늘 시사IN"
+    },
+    "64": {
+        "materials": [
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "“아무리 싸도 억” 송지효 부모님 통영 여객선 사업 큰 손이었다(런닝맨)[어제TV]",
+                "url": "http://news.newsen.com/news_view.php?uid=202307161856566710",
+                "aid": "955ae1a0debf2520",
+                "image": {
+                    "url": "https://s.pstatic.net/dthumb.phinf/?src=%22https%3A%2F%2Fs.pstatic.net%2Fstatic%2Fnewsstand%2F2023%2F0717%2Farticle_img%2Fnew_main%2F9126%2F085139_001.jpg%22&type=nf312_208&service=navermain"
+                },
+                "_id": "643542ba1f0f6898fc222111"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "김우빈→이찬원 폭우 피해에 ★ 기부 행렬 “도움 되기를” [종합]",
+                "url": "http://news.newsen.com/news_view.php?uid=202307161637415710",
+                "aid": "cffa229e4be4541e",
+                "image": null,
+                "_id": "64382002d2afac98f57ccef6"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "빅히트 뮤직 측 “BTS 정국 유튜브 집계 문제없다”[공식]",
+                "url": "http://news.newsen.com/news_view.php?uid=202307170753070410",
+                "aid": "fa821967f7653567",
+                "image": null,
+                "_id": "645661636e592107d2d4489a"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "강동원, 정용진 부회장 쌍둥이 남매 만나 깜짝 사인회 ‘삼촌미소’",
+                "url": "http://news.newsen.com/news_view.php?uid=202307170702342410",
+                "aid": "c32b29e3313554e3",
+                "image": null,
+                "_id": "646563463e93486eac614c31"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "“열심히 드럼 칠게요” 데이식스 도운, 성진·영케이 축하 속 만기 전역[종합]",
+                "url": "http://news.newsen.com/news_view.php?uid=202307162034360410",
+                "aid": "aa8593bc17e2a6fc",
+                "image": null,
+                "_id": "646563463e93486eac614c32"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "백진희 딸 낳았다, 안재현과 1년만 운명적 재회 (진짜가)[어제TV]",
+                "url": "http://news.newsen.com/news_view.php?uid=202307170600231710",
+                "aid": "c356eb24702c63a4",
+                "image": null,
+                "_id": "646563463e93486eac614c33"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "여자아이들 미연 ‘옅은 화장에도 예쁨 폭발’[포토엔HD]",
+                "url": "http://news.newsen.com/news_view.php?uid=202307161853393510",
+                "aid": "f36760832c1cb243",
+                "image": null,
+                "_id": "646563463e93486eac614c34"
+            }
+        ],
+        "name": "데일리한국"
+    },
+    "65": {
+        "materials": [
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "<마당이 있는 집> 원작자 김진영 인터뷰",
+                "url": "https://ch.yes24.com/Article/View/54599?y_contents=채널예스&y_channel=뉴스캐스트&y_area=61",
+                "aid": "7737d4728b170632",
+                "image": {
+                    "url": "https://s.pstatic.net/dthumb.phinf/?src=%22https%3A%2F%2Fs.pstatic.net%2Fstatic%2Fnewsstand%2F2023%2F0717%2Farticle_img%2Fnew_main%2F9084%2F113512_001.jpg%22&type=nf312_208&service=navermain"
+                },
+                "_id": "643542ba1f0f6898fc221ba7"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "What's in my cart? 책 장바구니 특집!",
+                "url": "https://ch.yes24.com/Article/View/54595?y_contents=채널예스&y_channel=뉴스캐스트&y_area=61",
+                "aid": "e232196e2093fc2e",
+                "image": null,
+                "_id": "648049361f0f6898fc301cae"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "삶이 우울하거나 지겨우면 이 작품을 보라!",
+                "url": "https://ch.yes24.com/Article/View/54591?y_contents=채널예스&y_channel=뉴스캐스트&y_area=61",
+                "aid": "4d2c5e6ab610f22a",
+                "image": null,
+                "_id": "64b4a4a660f3c014e7afd1a6"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "뮤지컬 <신의 손가락> - 모두의 인생은 한 편의 동화다",
+                "url": "https://ch.yes24.com/Article/View/54583?y_contents=채널예스&y_channel=뉴스캐스트&y_area=61",
+                "aid": "54c2d28d28660dcd",
+                "image": null,
+                "_id": "64b4a4a660f3c014e7afd1a7"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "색채를 찾아 떠나는 프로방스 여행",
+                "url": "https://ch.yes24.com/Article/View/54603?y_contents=채널예스&y_channel=뉴스캐스트&y_area=61",
+                "aid": "d8004a16f6443196",
+                "image": null,
+                "_id": "64b4a4a660f3c014e7afd1a8"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "[김소미의 혼자 영화관에 갔어] 외로운 방조자들의 우주 - <스파이더맨 : 어크로스 더 유니버스>",
+                "url": "https://ch.yes24.com/Article/View/54602?y_contents=채널예스&y_channel=뉴스캐스트&y_area=61",
+                "aid": "f2bedb555ba36f15",
+                "image": null,
+                "_id": "64b4a4a660f3c014e7afd1a9"
+            },
+            {
+                "@type": "MATERIAL-PC-NEWSSTAND-HEADLINE",
+                "gdid": null,
+                "title": "[임진아의 카페 생활] 여름 방학 기분 - 커먼마치",
+                "url": "https://ch.yes24.com/Article/View/54600?y_contents=채널예스&y_channel=뉴스캐스트&y_area=61",
+                "aid": "283bfdd32661ea13",
+                "image": null,
+                "_id": "64b4a4a660f3c014e7afd1aa"
+            }
+        ],
+        "name": "뉴스토마토"
+    }
+}

--- a/src/App.js
+++ b/src/App.js
@@ -9,7 +9,7 @@ import Rolling from "./App/Rolling.js";
 import Main from "./App/Main.js";
 
 export default function App($target, mode) {
-  this.state = "light";
+  this.state = "Light";
 
   this.setState = (nextState) => {
     this.state = nextState;

--- a/src/App/Main.js
+++ b/src/App/Main.js
@@ -41,7 +41,11 @@ export default function Main($target, props) {
       setViewerType: this.setViewerType,
       setPressType: this.setPressType,
     });
-    new MainContent($main, { ...props, ...this.state });
+    new MainContent($main, {
+      ...props,
+      ...this.state,
+      setPressType: this.setPressType,
+    });
 
     $target.appendChild($main);
   };

--- a/src/App/Main.js
+++ b/src/App/Main.js
@@ -3,8 +3,13 @@
  */
 import ContentNav from "./Main/ContentNav.js";
 import MainContent from "./Main/MainContent.js";
+import fetchNews from "../api/fetchNews.js";
+
+const newsData = await fetchNews();
 
 export default function Main($target, props) {
+  let $main = document.querySelector(".news");
+
   this.state = {
     viewerType: "grid",
     pressType: "all",
@@ -26,8 +31,6 @@ export default function Main($target, props) {
   };
 
   this.render = () => {
-    let $main = document.querySelector(".news");
-
     if ($main) {
       $main.innerHTML = "";
     } else {
@@ -36,7 +39,7 @@ export default function Main($target, props) {
     }
 
     new ContentNav($main, {
-      ...props,
+      mode: props.mode,
       ...this.state,
       setViewerType: this.setViewerType,
       setPressType: this.setPressType,

--- a/src/App/Main.js
+++ b/src/App/Main.js
@@ -3,9 +3,6 @@
  */
 import ContentNav from "./Main/ContentNav.js";
 import MainContent from "./Main/MainContent.js";
-import fetchNews from "../api/fetchNews.js";
-
-const newsData = await fetchNews();
 
 export default function Main($target, props) {
   let $main = document.querySelector(".news");

--- a/src/App/Main/MainContent.js
+++ b/src/App/Main/MainContent.js
@@ -37,13 +37,13 @@ export default function MainContent($target, props) {
 
   this.setState = (nextState) => {
     this.state = nextState;
-    suffile(this.state.lastPage);
+    suffile(lastPage);
     this.render();
   };
 
   this.setCategory = (nextCategory) => {
     this.state = { ...this.state, category: nextCategory % 7 };
-    suffile(this.state.lastPage);
+    suffile(lastPage);
     this.render();
   };
 
@@ -95,6 +95,7 @@ export default function MainContent($target, props) {
         setContentState: this.setState,
         timerArr: timerArr,
         indexArr: indexArr,
+        data: listViewData[this.state.category],
       };
 
       new NewsListView($section, listProps);

--- a/src/App/Main/MainContent.js
+++ b/src/App/Main/MainContent.js
@@ -16,6 +16,7 @@ const GRID_PRESS_NUBER = 24;
 let timerArr = [];
 let indexArr = getRandomIndexArr(4);
 
+const snackBarText = "내가 구독한 언론사에 추가되었습니다.";
 const cancelAnimation = () => {
   timerArr.forEach((timer) => {
     cancelAnimationFrame(timer);
@@ -30,6 +31,10 @@ const suffile = (len) => {
 export default function MainContent($target, props) {
   let $section = document.querySelector(".news-section");
   let lastPage;
+
+  let $div = document.createElement("div");
+  $div.setAttribute("class", "snack-bar");
+  $div.innerText = snackBarText;
 
   this.state = { currentPage: 1, category: 0 };
 
@@ -112,6 +117,7 @@ export default function MainContent($target, props) {
     new Button($section, { ...commonButtonProps, direction: "left" });
     new Button($section, { ...commonButtonProps, direction: "right" });
 
+    $section.appendChild($div);
     $target.appendChild($section);
   };
 

--- a/src/App/Main/MainContent.js
+++ b/src/App/Main/MainContent.js
@@ -3,11 +3,13 @@
 그리드 뷰, 리스트 뷰를 보여주는 컴포넌트
 */
 import getRandomIndexArr from "../../api/getRandomIndexArr.js";
+import fetchNews from "../../api/fetchNews.js";
 import Button from "./MainContent/Button.js";
 import PressGridView from "./MainContent/PressGridView.js";
 import NewsListView from "./MainContent/NewsListView.js";
 import store from "../../Store/Store.js";
 
+const listViewData = await fetchNews();
 const TOTAL_PRESS_NUMBER = 96;
 const GRID_PRESS_NUBER = 24;
 
@@ -27,10 +29,7 @@ const suffile = (len) => {
 
 export default function MainContent($target, props) {
   let $section = document.querySelector(".news-section");
-  let lastPage =
-    props.pressType === "all"
-      ? parseInt(TOTAL_PRESS_NUMBER / GRID_PRESS_NUBER)
-      : parseInt(store.myPressList.length / GRID_PRESS_NUBER + 1);
+  let lastPage;
 
   this.state = { currentPage: 1, category: 0 };
 
@@ -77,11 +76,21 @@ export default function MainContent($target, props) {
         ...commonProps,
       };
 
+      lastPage =
+        props.pressType === "all"
+          ? parseInt(TOTAL_PRESS_NUMBER / GRID_PRESS_NUBER)
+          : parseInt(store.myPressList.length / GRID_PRESS_NUBER + 1);
+
       new PressGridView($section, gridProps);
     } else {
+      lastPage =
+        props.pressType === "all"
+          ? listViewData[this.state.category].length
+          : 1;
+
       const listProps = {
         ...commonProps,
-        lastPage: this.state.lastPage,
+        lastPage: lastPage,
         category: this.state.category,
         setContentState: this.setState,
         timerArr: timerArr,

--- a/src/App/Main/MainContent.js
+++ b/src/App/Main/MainContent.js
@@ -98,6 +98,7 @@ export default function MainContent($target, props) {
         lastPage: lastPage,
         category: this.state.category,
         setContentState: this.setState,
+        setPressType: props.setPressType,
         timerArr: timerArr,
         indexArr: indexArr,
         data: listViewData[this.state.category],

--- a/src/App/Main/MainContent.js
+++ b/src/App/Main/MainContent.js
@@ -3,13 +3,14 @@
 그리드 뷰, 리스트 뷰를 보여주는 컴포넌트
 */
 import getRandomIndexArr from "../../api/getRandomIndexArr.js";
-import { fetchNews } from "../../api/fetchNews.js";
+import { fetchNews, fetchPress } from "../../api/fetchNews.js";
 import Button from "./MainContent/Button.js";
 import PressGridView from "./MainContent/PressGridView.js";
 import NewsListView from "./MainContent/NewsListView.js";
 import store from "../../Store/Store.js";
 
 const listViewData = await fetchNews();
+const pressData = await fetchPress();
 const TOTAL_PRESS_NUMBER = 96;
 const GRID_PRESS_NUBER = 24;
 
@@ -63,6 +64,7 @@ export default function MainContent($target, props) {
   };
 
   this.render = () => {
+    console.log(this.state.category);
     if ($section) {
       $target.removeChild($section);
     }
@@ -101,7 +103,13 @@ export default function MainContent($target, props) {
         setPressType: props.setPressType,
         timerArr: timerArr,
         indexArr: indexArr,
-        data: listViewData[this.state.category],
+        data:
+          props.pressType === "all"
+            ? listViewData[this.state.category]
+            : {
+                ...pressData[store.myPressList[this.state.category]],
+                pid: store.myPressList[this.state.category],
+              },
       };
 
       new NewsListView($section, listProps);

--- a/src/App/Main/MainContent.js
+++ b/src/App/Main/MainContent.js
@@ -3,7 +3,7 @@
 그리드 뷰, 리스트 뷰를 보여주는 컴포넌트
 */
 import getRandomIndexArr from "../../api/getRandomIndexArr.js";
-import fetchNews from "../../api/fetchNews.js";
+import { fetchNews } from "../../api/fetchNews.js";
 import Button from "./MainContent/Button.js";
 import PressGridView from "./MainContent/PressGridView.js";
 import NewsListView from "./MainContent/NewsListView.js";

--- a/src/App/Main/MainContent.js
+++ b/src/App/Main/MainContent.js
@@ -6,6 +6,10 @@ import getRandomIndexArr from "../../api/getRandomIndexArr.js";
 import Button from "./MainContent/Button.js";
 import PressGridView from "./MainContent/PressGridView.js";
 import NewsListView from "./MainContent/NewsListView.js";
+import store from "../../Store/Store.js";
+
+const TOTAL_PRESS_NUMBER = 96;
+const GRID_PRESS_NUBER = 24;
 
 let timerArr = [];
 let indexArr = getRandomIndexArr(4);
@@ -22,7 +26,13 @@ const suffile = (len) => {
 };
 
 export default function MainContent($target, props) {
-  this.state = { currentPage: 1, lastPage: 4, category: 0 };
+  let $section = document.querySelector(".news-section");
+  let lastPage =
+    props.pressType === "all"
+      ? parseInt(TOTAL_PRESS_NUMBER / GRID_PRESS_NUBER)
+      : parseInt(store.myPressList.length / GRID_PRESS_NUBER + 1);
+
+  this.state = { currentPage: 1, category: 0 };
 
   cancelAnimation();
 
@@ -49,8 +59,6 @@ export default function MainContent($target, props) {
   };
 
   this.render = () => {
-    let $section = document.querySelector(".news-section");
-
     if ($section) {
       $target.removeChild($section);
     }
@@ -60,7 +68,7 @@ export default function MainContent($target, props) {
 
     const commonProps = {
       mode: props.mode,
-      store: props.store,
+      pressType: props.pressType,
       currentPage: this.state.currentPage,
     };
 
@@ -84,9 +92,10 @@ export default function MainContent($target, props) {
     }
 
     const commonButtonProps = {
+      ...this.state,
       mode: props.mode,
       viewerType: props.viewerType,
-      ...this.state,
+      lastPage: lastPage,
       onClick: this.setCurrentPage,
     };
 

--- a/src/App/Main/MainContent.js
+++ b/src/App/Main/MainContent.js
@@ -2,13 +2,13 @@
 메인 컨텐츠 컴포넌트
 그리드 뷰, 리스트 뷰를 보여주는 컴포넌트
 */
+import getRandomIndexArr from "../../api/getRandomIndexArr.js";
 import Button from "./MainContent/Button.js";
 import PressGridView from "./MainContent/PressGridView.js";
 import NewsListView from "./MainContent/NewsListView.js";
 
 let timerArr = [];
-let indexArr = Array.from({ length: 4 }, (_, i) => i);
-indexArr.sort(() => Math.random() - 0.5);
+let indexArr = getRandomIndexArr(4);
 
 const cancelAnimation = () => {
   timerArr.forEach((timer) => {
@@ -60,6 +60,7 @@ export default function MainContent($target, props) {
 
     const commonProps = {
       mode: props.mode,
+      store: props.store,
       currentPage: this.state.currentPage,
     };
 
@@ -84,6 +85,7 @@ export default function MainContent($target, props) {
 
     const commonButtonProps = {
       mode: props.mode,
+      viewerType: props.viewerType,
       ...this.state,
       onClick: this.setCurrentPage,
     };

--- a/src/App/Main/MainContent/Button.js
+++ b/src/App/Main/MainContent/Button.js
@@ -45,6 +45,7 @@ export default function Button($target, props) {
         props.onClick(props.currentPage + 1);
       });
     }
+
     $target.appendChild($button);
   };
 

--- a/src/App/Main/MainContent/NewsListView.js
+++ b/src/App/Main/MainContent/NewsListView.js
@@ -72,6 +72,7 @@ export default function NewsListView($target, props) {
       pressId: getPressId(newsOject),
       pressLogo: getPressLogo(newsOject, props.mode),
       editDate: getEditDate(newsOject),
+      setPressType: props.setPressType,
     },
     newsData: {
       mainNewsData: {

--- a/src/App/Main/MainContent/NewsListView.js
+++ b/src/App/Main/MainContent/NewsListView.js
@@ -54,10 +54,14 @@ const getPressId = function (object) {
 export default function NewsListView($target, props) {
   if (prevCategory !== props.category) {
     prevCategory = props.category;
-    indexArr = getRandomIndexArr(props.data.length);
+    if (props.pressType === "all")
+      indexArr = getRandomIndexArr(props.data.length);
   }
 
-  const newsOject = props.data[indexArr[props.currentPage - 1]];
+  const newsOject =
+    props.pressType === "all"
+      ? props.data[indexArr[props.currentPage - 1]]
+      : props.data;
 
   const categoryNavProps = {
     pressType: props.pressType,
@@ -70,7 +74,8 @@ export default function NewsListView($target, props) {
 
   const contentsProps = {
     headerData: {
-      pressId: getPressId(newsOject),
+      pressId:
+        props.pressType === "all" ? getPressId(newsOject) : newsOject.pid,
       pressLogo: getPressLogo(newsOject, props.mode),
       editDate: getEditDate(newsOject),
       setPressType: props.setPressType,

--- a/src/App/Main/MainContent/NewsListView.js
+++ b/src/App/Main/MainContent/NewsListView.js
@@ -5,34 +5,55 @@
 
 import CategoryNav from "./NewsListView/CategoryNav.js";
 import Contents from "./NewsListView/Contents.js";
+import getRandomIndexArr from "../../../api/getRandomIndexArr.js";
 
-let subTitles = [
-  `"위스키 사려고 이틀전부터 줄 섰어요"`,
-  `'방시혁 제국'이냐 '카카오 왕국'이냐…K엔터 누가 거머쥘까`,
-  `사용후핵연료 저장시설 포화…이대론 7년 뒤 원전 멈춘다`,
-  `[단독] 원희룡 "해외건설 근로자 소득공제 월 500만원으로 상향할 것"`,
-  `태평양에는 우영우의 고래만 있는게 아니었다 [로비의 그림]`,
-  `LG엔솔, 폴란드 자동차산업협회 가입…“유럽서 목소리 키운다”`,
-];
+let indexArr;
+let prevCategory = undefined;
 
-const pressArr = [
-  "머니투데이",
-  "경향신문",
-  "뉴스타파",
-  "오마이뉴스",
-  "데일리안",
-  "스포츠서울",
-  "스포츠동아",
-  "문화일보",
-  "KBS WORLD",
-  "한국중앙데일리",
-  "인사이트",
-  "법률방송뉴스",
-];
+const getPressLogo = function (object, mode) {
+  return object[`logo${mode}`].url;
+};
 
-const editDate = "2023.02.10 18:27 편집";
+const getEditDate = function (object) {
+  let [date, time] = object.regDate.split(" ");
 
+  let year = date.substring(0, 4);
+  let month = date.substring(4, 6);
+  let day = date.substring(6, 8);
+
+  date = `${year}.${month}.${day}`;
+  time = time.substring(0, 5);
+
+  return `${date} ${time} 편집`;
+};
+
+const getMainThumbnail = function (object) {
+  return object.materials[0].image.url;
+};
+
+const getMainNewsTitle = function (object) {
+  return object.materials[0].title;
+};
+
+const getsubTitles = function (object) {
+  const titles = [];
+  object.materials.slice(1).forEach((element) => {
+    titles.push(element.title);
+  });
+  return titles;
+};
+
+const getPressName = function (object) {
+  return object.name;
+};
 export default function NewsListView($target, props) {
+  if (prevCategory !== props.category) {
+    prevCategory = props.category;
+    indexArr = getRandomIndexArr(props.data.length);
+  }
+
+  const newsOject = props.data[indexArr[props.currentPage - 1]];
+
   const categoryNavProps = {
     pressType: props.pressType,
     currentPage: props.currentPage,
@@ -44,21 +65,17 @@ export default function NewsListView($target, props) {
 
   const contentsProps = {
     headerData: {
-      pressLogo: `./assets/newspaper/${props.mode}/${
-        props.indexArr[props.currentPage - 1] + 1
-      }.png`,
-      editDate: editDate,
+      pressLogo: getPressLogo(newsOject, props.mode),
+      editDate: getEditDate(newsOject),
     },
     newsData: {
       mainNewsData: {
-        mainThumbnail: "https://picsum.photos/320/200",
-        mainNewsTitle: `또 국민연금의 몽니…현대百 지주사 불발 ${
-          props.indexArr[props.currentPage - 1]
-        }`,
+        mainThumbnail: getMainThumbnail(newsOject),
+        mainNewsTitle: getMainNewsTitle(newsOject),
       },
       subNewsData: {
-        subTitles: subTitles,
-        press: pressArr[props.indexArr[props.currentPage - 1]],
+        subTitles: getsubTitles(newsOject),
+        press: getPressName(newsOject),
       },
     },
   };

--- a/src/App/Main/MainContent/NewsListView.js
+++ b/src/App/Main/MainContent/NewsListView.js
@@ -50,6 +50,7 @@ const getPressName = function (object) {
 const getPressId = function (object) {
   return object.pid;
 };
+
 export default function NewsListView($target, props) {
   if (prevCategory !== props.category) {
     prevCategory = props.category;

--- a/src/App/Main/MainContent/NewsListView.js
+++ b/src/App/Main/MainContent/NewsListView.js
@@ -46,6 +46,10 @@ const getsubTitles = function (object) {
 const getPressName = function (object) {
   return object.name;
 };
+
+const getPressId = function (object) {
+  return object.pid;
+};
 export default function NewsListView($target, props) {
   if (prevCategory !== props.category) {
     prevCategory = props.category;
@@ -65,6 +69,7 @@ export default function NewsListView($target, props) {
 
   const contentsProps = {
     headerData: {
+      pressId: getPressId(newsOject),
       pressLogo: getPressLogo(newsOject, props.mode),
       editDate: getEditDate(newsOject),
     },

--- a/src/App/Main/MainContent/NewsListView/CategoryNav.js
+++ b/src/App/Main/MainContent/NewsListView/CategoryNav.js
@@ -47,13 +47,13 @@ export default function CategoryNav($target, props) {
         if (props.currentPage === props.lastPage) {
           // change category
           if (props.category === LAST_CATEGORY) {
-            // props.setContentState(initCategoryState);
+            props.setContentState(initCategoryState);
           } else {
-            // props.setContentState(nextCategoryState);
+            props.setContentState(nextCategoryState);
           }
         } else {
           // change page
-          // props.setContentState(nextPageState);
+          props.setContentState(nextPageState);
         }
       }
 
@@ -103,7 +103,6 @@ export default function CategoryNav($target, props) {
 
         props.setContentState({
           currentPage: 1,
-          lastPage: categoryLengthArr[targetElement.dataset.key],
           category: Number(targetElement.dataset.key),
         });
       }

--- a/src/App/Main/MainContent/NewsListView/CategoryNav.js
+++ b/src/App/Main/MainContent/NewsListView/CategoryNav.js
@@ -1,12 +1,49 @@
 /*
 기사 컨텐츠 네비게이션 컴포넌트
 */
+
+import store from "../../../../Store/Store.js";
+import { fetchPress } from "../../../../api/fetchNews.js";
+
+const press = await fetchPress();
+
+const categories = [
+  "종합/경제",
+  "방송/통신",
+  "IT",
+  "영자지",
+  "스포츠/연예",
+  "매거진/전문지",
+  "지역",
+];
+
 const FIRST_CATEGORY = 0;
 const LAST_CATEGORY = 6;
 
 const FIRST_PAGE = 1;
 
 const categoryLengthArr = [4, 12, 3, 5, 6, 4, 7, 10];
+
+const arrowIcon = `<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 14 14" fill="none">
+<path d="M5.48341 10.5L4.66675 9.68333L7.35008 7L4.66675 4.31667L5.48341 3.5L8.98342 7L5.48341 10.5Z" fill="white"/>
+</svg>`;
+const createNav = function (pressType, navElements) {
+  let liString = "";
+
+  const indexArr = Array.from({ length: navElements.length }, (_, i) => i);
+  liString = indexArr.reduce((accumulator, index) => {
+    return (
+      accumulator +
+      `<li data-key=${index}><span>${
+        pressType === "all"
+          ? navElements[index]
+          : press[store.myPressList[index]].name
+      }</span></li>`
+    );
+  }, "");
+
+  return liString;
+};
 
 export default function CategoryNav($target, props) {
   const initCategoryState = {
@@ -47,13 +84,13 @@ export default function CategoryNav($target, props) {
         if (props.currentPage === props.lastPage) {
           // change category
           if (props.category === LAST_CATEGORY) {
-            props.setContentState(initCategoryState);
+            // props.setContentState(initCategoryState);
           } else {
-            props.setContentState(nextCategoryState);
+            // props.setContentState(nextCategoryState);
           }
         } else {
           // change page
-          props.setContentState(nextPageState);
+          // props.setContentState(nextPageState);
         }
       }
 
@@ -76,15 +113,10 @@ export default function CategoryNav($target, props) {
     const $ul = document.createElement("ul");
     $ul.setAttribute("class", "categoty-list");
 
-    $ul.innerHTML = `
-    <li data-key=0><span>종합/경제</span></li>
-    <li data-key=1><span>방송/통신</span></li>
-    <li data-key=2><span>IT</span></li>
-    <li data-key=3><span>영자지</span></li>
-    <li data-key=4><span>스포츠/연예</span></li>
-    <li data-key=5><span>매거진/전문지</span></li>
-    <li data-key=6><span>지역</span></li>
-    `;
+    $ul.innerHTML =
+      props.pressType === "all"
+        ? createNav("all", categories)
+        : createNav("my", store.myPressList);
 
     $ul.addEventListener("click", (e) => {
       let targetElement = e.target;
@@ -116,7 +148,16 @@ export default function CategoryNav($target, props) {
 
     targetElement.style.zIndex = 1;
     targetElement.classList.add("select");
-    targetElement.innerHTML += `<span>${props.currentPage}/${props.lastPage}</span>`;
+
+    // if pressType all
+    targetElement.innerHTML += `<span>
+    ${
+      props.pressType === "all"
+        ? `${props.currentPage}/${props.lastPage}`
+        : arrowIcon
+    }
+    </span>`;
+
     targetElement.appendChild($div);
 
     $nav.appendChild($ul);

--- a/src/App/Main/MainContent/NewsListView/CategoryNav.js
+++ b/src/App/Main/MainContent/NewsListView/CategoryNav.js
@@ -22,8 +22,6 @@ const LAST_CATEGORY = 6;
 
 const FIRST_PAGE = 1;
 
-const categoryLengthArr = [4, 12, 3, 5, 6, 4, 7, 10];
-
 const arrowIcon = `<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 14 14" fill="none">
 <path d="M5.48341 10.5L4.66675 9.68333L7.35008 7L4.66675 4.31667L5.48341 3.5L8.98342 7L5.48341 10.5Z" fill="white"/>
 </svg>`;
@@ -48,19 +46,16 @@ const createNav = function (pressType, navElements) {
 export default function CategoryNav($target, props) {
   const initCategoryState = {
     currentPage: FIRST_PAGE,
-    lastPage: categoryLengthArr[FIRST_CATEGORY],
     category: FIRST_CATEGORY,
   };
 
   const nextCategoryState = {
     currentPage: 1,
-    lastPage: categoryLengthArr[props.category + 1],
     category: props.category + 1,
   };
 
   const nextPageState = {
     currentPage: props.currentPage + 1,
-    lastPage: props.lastPage,
     category: props.category,
   };
 
@@ -84,13 +79,13 @@ export default function CategoryNav($target, props) {
         if (props.currentPage === props.lastPage) {
           // change category
           if (props.category === LAST_CATEGORY) {
-            // props.setContentState(initCategoryState);
+            props.setContentState(initCategoryState);
           } else {
-            // props.setContentState(nextCategoryState);
+            props.setContentState(nextCategoryState);
           }
         } else {
           // change page
-          // props.setContentState(nextPageState);
+          props.setContentState(nextPageState);
         }
       }
 

--- a/src/App/Main/MainContent/NewsListView/CategoryNav.js
+++ b/src/App/Main/MainContent/NewsListView/CategoryNav.js
@@ -47,13 +47,13 @@ export default function CategoryNav($target, props) {
         if (props.currentPage === props.lastPage) {
           // change category
           if (props.category === LAST_CATEGORY) {
-            props.setContentState(initCategoryState);
+            // props.setContentState(initCategoryState);
           } else {
-            props.setContentState(nextCategoryState);
+            // props.setContentState(nextCategoryState);
           }
         } else {
           // change page
-          props.setContentState(nextPageState);
+          // props.setContentState(nextPageState);
         }
       }
 

--- a/src/App/Main/MainContent/NewsListView/CategoryNav.js
+++ b/src/App/Main/MainContent/NewsListView/CategoryNav.js
@@ -87,8 +87,6 @@ export default function CategoryNav($target, props) {
     `;
 
     $ul.addEventListener("click", (e) => {
-      // data fetch
-
       let targetElement = e.target;
 
       while (targetElement && targetElement.tagName !== "LI")

--- a/src/App/Main/MainContent/NewsListView/Contents/Header.js
+++ b/src/App/Main/MainContent/NewsListView/Contents/Header.js
@@ -34,7 +34,11 @@ export default function Contents($target, props) {
         $button.innerHTML = unsubscribeButtonInner;
 
         const snackBar = document.querySelector(".snack-bar");
-        snackBar.style.display = "block";
+        snackBar.style.opacity = "100";
+
+        setTimeout(() => {
+          snackBar.style.opacity = "0";
+        }, 5000);
       });
     } else {
       $button.innerHTML = unsubscribeButtonInner;

--- a/src/App/Main/MainContent/NewsListView/Contents/Header.js
+++ b/src/App/Main/MainContent/NewsListView/Contents/Header.js
@@ -3,6 +3,16 @@
 */
 import store from "../../../../../Store/Store.js";
 
+const subscribeButtonInner = `<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none">
+<path d="M19 12.998H13V18.998H11V12.998H5V10.998H11V4.99799H13V10.998H19V12.998Z" fill="#879298"/>
+</svg> 구독하기`;
+
+const unsubscribeButtonInner = `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
+<rect x="0.5" y="0.5" width="23" height="23" rx="11.5" fill="white"/>
+<path d="M9.6 15L9 14.4L11.4 12L9 9.6L9.6 9L12 11.4L14.4 9L15 9.6L12.6 12L15 14.4L14.4 15L12 12.6L9.6 15Z" fill="#879298"/>
+<rect x="0.5" y="0.5" width="23" height="23" rx="11.5" stroke="#D2DAE0"/>
+</svg>`;
+
 export default function Contents($target, props) {
   this.render = () => {
     const $header = document.createElement("header");
@@ -13,13 +23,22 @@ export default function Contents($target, props) {
     $header.setAttribute("class", "list-header");
     $img.setAttribute("class", "list-img");
     $div.setAttribute("class", "list-edit");
-    $button.setAttribute("class", "subscribe-btn");
+
+    if (!store.isSubscribed(props.pressId)) {
+      $button.setAttribute("class", "subscribe-btn");
+      $button.innerHTML = subscribeButtonInner;
+      $button.addEventListener("click", () => {
+        store.dispatch("구독하기", props.pressId);
+      });
+    } else {
+      $button.innerHTML = unsubscribeButtonInner;
+      $button.addEventListener("click", () => {
+        store.dispatch("해지하기", props.pressId);
+      });
+    }
 
     $img.src = props.pressLogo;
     $div.innerHTML = props.editDate;
-    $button.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none">
-    <path d="M19 12.998H13V18.998H11V12.998H5V10.998H11V4.99799H13V10.998H19V12.998Z" fill="#879298"/>
-    </svg> 구독하기`;
 
     $header.appendChild($img);
     $header.appendChild($div);

--- a/src/App/Main/MainContent/NewsListView/Contents/Header.js
+++ b/src/App/Main/MainContent/NewsListView/Contents/Header.js
@@ -27,13 +27,18 @@ export default function Contents($target, props) {
     if (!store.isSubscribed(props.pressId)) {
       $button.setAttribute("class", "subscribe-btn");
       $button.innerHTML = subscribeButtonInner;
+
       $button.addEventListener("click", () => {
         store.dispatch("구독하기", props.pressId);
         $button.classList.remove("subscribe-btn");
         $button.innerHTML = unsubscribeButtonInner;
+
+        const snackBar = document.querySelector(".snack-bar");
+        snackBar.style.display = "block";
       });
     } else {
       $button.innerHTML = unsubscribeButtonInner;
+
       $button.addEventListener("click", () => {
         store.dispatch("해지하기", props.pressId);
         $button.setAttribute("class", "subscribe-btn");

--- a/src/App/Main/MainContent/NewsListView/Contents/Header.js
+++ b/src/App/Main/MainContent/NewsListView/Contents/Header.js
@@ -29,11 +29,15 @@ export default function Contents($target, props) {
       $button.innerHTML = subscribeButtonInner;
       $button.addEventListener("click", () => {
         store.dispatch("구독하기", props.pressId);
+        $button.classList.remove("subscribe-btn");
+        $button.innerHTML = unsubscribeButtonInner;
       });
     } else {
       $button.innerHTML = unsubscribeButtonInner;
       $button.addEventListener("click", () => {
         store.dispatch("해지하기", props.pressId);
+        $button.setAttribute("class", "subscribe-btn");
+        $button.innerHTML = subscribeButtonInner;
       });
     }
 

--- a/src/App/Main/MainContent/NewsListView/Contents/Header.js
+++ b/src/App/Main/MainContent/NewsListView/Contents/Header.js
@@ -3,17 +3,11 @@
 */
 import store from "../../../../../Store/Store.js";
 
-const subscribeButtonInner = `<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none">
-<path d="M19 12.998H13V18.998H11V12.998H5V10.998H11V4.99799H13V10.998H19V12.998Z" fill="#879298"/>
-</svg> 구독하기`;
+const subscribeButtonInner = `<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none"><path d="M19 12.998H13V18.998H11V12.998H5V10.998H11V4.99799H13V10.998H19V12.998Z" fill="#879298"/></svg>구독하기`;
 
-const unsubscribeButtonInner = `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
-<rect x="0.5" y="0.5" width="23" height="23" rx="11.5" fill="white"/>
-<path d="M9.6 15L9 14.4L11.4 12L9 9.6L9.6 9L12 11.4L14.4 9L15 9.6L12.6 12L15 14.4L14.4 15L12 12.6L9.6 15Z" fill="#879298"/>
-<rect x="0.5" y="0.5" width="23" height="23" rx="11.5" stroke="#D2DAE0"/>
-</svg>`;
+const unsubscribeButtonInner = `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none"><rect x="0.5" y="0.5" width="23" height="23" rx="11.5" fill="white"/><path d="M9.6 15L9 14.4L11.4 12L9 9.6L9.6 9L12 11.4L14.4 9L15 9.6L12.6 12L15 14.4L14.4 15L12 12.6L9.6 15Z" fill="#879298"/><rect x="0.5" y="0.5" width="23" height="23" rx="11.5" stroke="#D2DAE0"/></svg>`;
 
-export default function Contents($target, props) {
+export default function Header($target, props) {
   this.render = () => {
     const $header = document.createElement("header");
     const $img = document.createElement("img");
@@ -27,28 +21,32 @@ export default function Contents($target, props) {
     if (!store.isSubscribed(props.pressId)) {
       $button.setAttribute("class", "subscribe-btn");
       $button.innerHTML = subscribeButtonInner;
+    } else {
+      $button.innerHTML = unsubscribeButtonInner;
+    }
 
-      $button.addEventListener("click", () => {
+    $button.addEventListener("click", (e) => {
+      if (e.currentTarget.className === "subscribe-btn") {
         store.dispatch("구독하기", props.pressId);
         $button.classList.remove("subscribe-btn");
         $button.innerHTML = unsubscribeButtonInner;
 
         const snackBar = document.querySelector(".snack-bar");
-        snackBar.style.opacity = "100";
 
+        snackBar.style.zIndex = 1;
+        snackBar.style.opacity = "100";
         setTimeout(() => {
           snackBar.style.opacity = "0";
-        }, 5000);
-      });
-    } else {
-      $button.innerHTML = unsubscribeButtonInner;
+          snackBar.style.zIndex = -1;
 
-      $button.addEventListener("click", () => {
+          props.setPressType("my");
+        }, 5000);
+      } else {
         store.dispatch("해지하기", props.pressId);
         $button.setAttribute("class", "subscribe-btn");
         $button.innerHTML = subscribeButtonInner;
-      });
-    }
+      }
+    });
 
     $img.src = props.pressLogo;
     $div.innerHTML = props.editDate;

--- a/src/App/Main/MainContent/NewsListView/Contents/Header.js
+++ b/src/App/Main/MainContent/NewsListView/Contents/Header.js
@@ -1,6 +1,8 @@
 /* 
 리스트 뷰  헤더 컴포넌트
 */
+import store from "../../../../../Store/Store.js";
+
 export default function Contents($target, props) {
   this.render = () => {
     const $header = document.createElement("header");

--- a/src/App/Main/MainContent/NewsListView/Contents/News/MainNews.js
+++ b/src/App/Main/MainContent/NewsListView/Contents/News/MainNews.js
@@ -31,8 +31,6 @@ export default function MainNews($target, props) {
     $childDiv.setAttribute("class", "main-title");
 
     $imgContainer.style.overflow = "hidden";
-    console.log($imgContainer.style);
-
     $img.src = props.mainThumbnail;
     $childDiv.innerHTML = props.mainNewsTitle;
 
@@ -49,6 +47,7 @@ export default function MainNews($target, props) {
       $img.style.scale = "none";
       $childDiv.style.textDecoration = "none";
     });
+
     $target.appendChild($div);
   };
 

--- a/src/App/Main/MainContent/NewsListView/Contents/News/MainNews.js
+++ b/src/App/Main/MainContent/NewsListView/Contents/News/MainNews.js
@@ -2,21 +2,53 @@
 리스트 뉴스 컨테이너 컴포넌트
 */
 
+const findTargetChildNode = (element, targetTagName) => {
+  if (!element) return null;
+
+  const children = Array.from(element.children);
+
+  for (const child of children) {
+    if (child.tagName.toLowerCase() === targetTagName.toLowerCase()) {
+      return child;
+    }
+
+    const matchedElement = findTargetChildNode(child, targetTagName);
+    if (matchedElement) return matchedElement;
+  }
+
+  return null;
+};
+
 export default function MainNews($target, props) {
   this.render = () => {
     const $div = document.createElement("div");
+    const $imgContainer = document.createElement("div");
     const $img = document.createElement("img");
     const $childDiv = document.createElement("div");
 
     $div.setAttribute("class", "main-news");
+    $imgContainer.setAttribute("class", "img-container");
     $childDiv.setAttribute("class", "main-title");
+
+    $imgContainer.style.overflow = "hidden";
+    console.log($imgContainer.style);
 
     $img.src = props.mainThumbnail;
     $childDiv.innerHTML = props.mainNewsTitle;
 
-    $div.appendChild($img);
+    $imgContainer.appendChild($img);
+    $div.appendChild($imgContainer);
     $div.appendChild($childDiv);
 
+    $div.addEventListener("mouseover", () => {
+      $img.style.scale = "105%";
+      $childDiv.style.textDecoration = "underline";
+    });
+
+    $div.addEventListener("mouseout", () => {
+      $img.style.scale = "none";
+      $childDiv.style.textDecoration = "none";
+    });
     $target.appendChild($div);
   };
 

--- a/src/App/Main/MainContent/NewsListView/Contents/News/SubNews.js
+++ b/src/App/Main/MainContent/NewsListView/Contents/News/SubNews.js
@@ -10,7 +10,8 @@ export default function SubNews($target, props) {
     $div.setAttribute("class", "sub-news");
 
     let inner = props.subTitles.reduce(
-      (accumulator, currentValue) => accumulator + `<li>${currentValue}</li>`,
+      (accumulator, currentValue) =>
+        accumulator + `<li class="sub-title">${currentValue}</li>`,
       ""
     );
 

--- a/src/App/Main/MainContent/PressGridView.js
+++ b/src/App/Main/MainContent/PressGridView.js
@@ -49,7 +49,13 @@ const viewSubscriptionButton = (e) => {
   if (btn) btn.style.display = "inline";
 };
 
+const isSubscribed = (pressid) => {
+  return true;
+};
+
 const createNewspaperItem = function (index, mode) {
+  const buttonText = isSubscribed(index + 1) ? "해지하기" : "구독하기";
+
   return `
     <li class="newspaper__item">
     <img src="./assets/newspaper/${mode}/${index + 1}.png" alt=${"name"} />
@@ -57,7 +63,9 @@ const createNewspaperItem = function (index, mode) {
       index + 1
     }><svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none">
     <path d="M19 12.998H13V18.998H11V12.998H5V10.998H11V4.99799H13V10.998H19V12.998Z" fill="#879298"/>
-    </svg>구독하기</button>
+    </svg>
+    ${buttonText}
+    </button>
     </li>
     `;
 };

--- a/src/App/Main/MainContent/PressGridView.js
+++ b/src/App/Main/MainContent/PressGridView.js
@@ -2,8 +2,8 @@
 신문사 컨텐츠 컴포넌트
 */
 import getRandomIndexArr from "../../../api/getRandomIndexArr.js";
+import findTargetChildNode from "../../../api/findTargetChildNode.js";
 import store from "../../../Store/Store.js";
-import findTargetParentNode from "../../../api/findTargetParentNode.js";
 
 const TOTAL_PRESS_NUMBER = 96;
 const GRID_PRESS_NUBER = 24;
@@ -16,58 +16,65 @@ const unsubscibeButtonInner = `<svg xmlns="http://www.w3.org/2000/svg" width="13
   <path d="M4.26699 9L3.66699 8.4L6.06699 6L3.66699 3.6L4.26699 3L6.66699 5.4L9.06699 3L9.66699 3.6L7.26699 6L9.66699 8.4L9.06699 9L6.66699 6.6L4.26699 9Z" fill="#879298"/>
   </svg>해지하기`;
 
-const indexArr = getRandomIndexArr(TOTAL_PRESS_NUMBER);
+let indexArr;
 
-const findTargetChildNode = (element, targetTagName) => {
-  if (!element) return null;
-
-  if (element.tagName.toLowerCase() === targetTagName.toLowerCase())
-    return element;
-
-  const children = Array.from(element.children);
-
-  for (const child of children) {
-    if (child.tagName.toLowerCase() === targetTagName.toLowerCase()) {
-      return child;
-    }
-
-    const matchedElement = findTargetChildNode(child, targetTagName);
-    if (matchedElement) return matchedElement;
-  }
-
-  return null;
-};
-
-const createNewspaperItem = function (index, mode) {
-  const pressId = index + 1;
-  const buttonInner = store.isSubscribed(String(pressId))
+const createButtonHTML = function (pressId, mode) {
+  const buttonInner = store.isSubscribed(pressId)
     ? unsubscibeButtonInner
     : subscibeButtonInner;
 
-  const inner = `<img src="./assets/newspaper/${mode}/${pressId}.png" alt=${"name"} />
-  <button class="subscribe-btn" data-key=${pressId}>
-  ${buttonInner}
-  </button>`;
+  return `
+<button class="subscribe-btn" data-key=${pressId}>
+${buttonInner}
+</button>`;
+};
+
+const allPressArr = Array.from({ length: TOTAL_PRESS_NUMBER }, (_, i) => i + 1);
+const createNewspaperItem = function (index, pressArr, mode) {
+  const pressId = String(pressArr[index]);
+  const button = createButtonHTML(pressId, mode);
 
   return `
-    <li class=${pressId ? "newspaper__item" : "blank"}>
-    ${pressId ? inner : ""}
+    <li class=${index > -1 ? "newspaper__item" : "blank"}>
+    ${
+      index > -1
+        ? `<img src="./assets/newspaper/${mode}/${pressId}.png" alt=${"name"} />`
+        : ""
+    }
+    ${index > -1 ? button : ""}
     </li>
     `;
 };
 
-const createPressList = function (page, mode) {
+const createPressList = function (page, pressArr, mode) {
   const nowPageIndexArr = indexArr.slice(
     (page - 1) * GRID_PRESS_NUBER,
     page * GRID_PRESS_NUBER
   );
 
-  while (nowPageIndexArr.length < 24) nowPageIndexArr.push(-1);
+  while (nowPageIndexArr.length < GRID_PRESS_NUBER) nowPageIndexArr.push(-1);
 
-  const liArr = nowPageIndexArr.map((item) => createNewspaperItem(item, mode));
+  const liArr = nowPageIndexArr.map((item) =>
+    createNewspaperItem(item, pressArr, mode)
+  );
   let pressList = liArr.reduce((news, currentIndex) => news + currentIndex);
 
   return pressList;
+};
+
+const handleSubscriptionButtonClick = (e) => {
+  let $button;
+  if (e.currentTarget !== e.target) {
+    $button = findTargetChildNode(e.target, "button");
+    if ($button) {
+      store.dispatch($button.innerText, $button.dataset.key);
+
+      $button.innerHTML =
+        $button.innerText === "구독하기"
+          ? unsubscibeButtonInner
+          : subscibeButtonInner;
+    }
+  }
 };
 
 export default function PressGridView($target, props) {
@@ -75,23 +82,25 @@ export default function PressGridView($target, props) {
     const $ul = document.createElement("ul");
 
     $ul.setAttribute("class", "newspaper__list");
-    $ul.innerHTML = createPressList(props.currentPage, props.mode);
 
-    $ul.addEventListener("click", (e) => {
-      let $button;
-      if (e.currentTarget !== e.target) {
-        $button = findTargetChildNode(e.target, "button");
-        console.log($button);
-        store.dispatch($button.innerText, $button.dataset.key);
+    if (props.pressType === "all") {
+      indexArr = getRandomIndexArr(TOTAL_PRESS_NUMBER);
+      $ul.innerHTML = createPressList(
+        props.currentPage,
+        allPressArr,
+        props.mode
+      );
+    } else {
+      indexArr = getRandomIndexArr(store.myPressList.length);
+      $ul.innerHTML = createPressList(
+        props.currentPage,
+        store.myPressList,
+        props.mode
+      );
+    }
 
-        $button.innerHTML =
-          $button.innerText === "구독하기"
-            ? unsubscibeButtonInner
-            : subscibeButtonInner;
+    $ul.addEventListener("click", handleSubscriptionButtonClick);
 
-        console.log(store.myPressList);
-      }
-    });
     $target.innerHTML = "";
     $target.appendChild($ul);
   };

--- a/src/App/Main/MainContent/PressGridView.js
+++ b/src/App/Main/MainContent/PressGridView.js
@@ -8,10 +8,56 @@ const GRID_PRESS_NUBER = 24;
 const indexArr = Array.from({ length: TOTAL_PRESS_NUMBER }, (_, i) => i);
 indexArr.sort(() => Math.random() - 0.5);
 
+const findTargetParentNode = (element, targetTagName) => {
+  if (!element) {
+    return null;
+  }
+
+  if (element.tagName === targetTagName) {
+    return element;
+  }
+
+  return findTargetParentNode(element.parentNode, targetTagName);
+};
+
+const findTargetChildNode = (element, targetTagName) => {
+  if (!element) return null;
+
+  const children = Array.from(element.children);
+
+  for (const child of children) {
+    if (child.tagName.toLowerCase() === targetTagName.toLowerCase()) {
+      return child;
+    }
+
+    const matchedElement = findTargetChildNode(child, targetTagName);
+    if (matchedElement) return matchedElement;
+  }
+
+  return null;
+};
+
+const viewSubscriptionButton = (e) => {
+  let target = e.target;
+  let img, btn;
+
+  target = findTargetParentNode(target, "LI");
+  img = findTargetChildNode(target, "img");
+  btn = findTargetChildNode(target, "button");
+
+  if (img) img.style.display = "none";
+  if (btn) btn.style.display = "inline";
+};
+
 const createNewspaperItem = function (index, mode) {
   return `
     <li class="newspaper__item">
     <img src="./assets/newspaper/${mode}/${index + 1}.png" alt=${"name"} />
+    <button class="subscribe-btn" data-key=${
+      index + 1
+    }><svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none">
+    <path d="M19 12.998H13V18.998H11V12.998H5V10.998H11V4.99799H13V10.998H19V12.998Z" fill="#879298"/>
+    </svg>구독하기</button>
     </li>
     `;
 };
@@ -32,7 +78,20 @@ export default function PressGridView($target, props) {
     const $ul = document.createElement("ul");
 
     $ul.setAttribute("class", "newspaper__list");
+
+    $ul.addEventListener("mouseover", viewSubscriptionButton);
+
     $ul.innerHTML = createPressList(props.currentPage, props.mode);
+
+    $ul.childNodes.forEach((elem) => {
+      elem.addEventListener("mouseout", (e) => {
+        const img = findTargetChildNode(e.target, "img");
+        const btn = findTargetChildNode(e.target, "button");
+
+        if (img) img.style.display = "inline";
+        if (btn) btn.style.display = "none";
+      });
+    });
 
     $target.innerHTML = "";
     $target.appendChild($ul);

--- a/src/App/Main/MainContent/PressGridView.js
+++ b/src/App/Main/MainContent/PressGridView.js
@@ -15,6 +15,7 @@ const subscibeButtonInner = `<svg xmlns="http://www.w3.org/2000/svg" width="12" 
 const unsubscibeButtonInner = `<svg xmlns="http://www.w3.org/2000/svg" width="13" height="12" viewBox="0 0 13 12" fill="none">
   <path d="M4.26699 9L3.66699 8.4L6.06699 6L3.66699 3.6L4.26699 3L6.66699 5.4L9.06699 3L9.66699 3.6L7.26699 6L9.66699 8.4L9.06699 9L6.66699 6.6L4.26699 9Z" fill="#879298"/>
   </svg>해지하기`;
+
 const indexArr = getRandomIndexArr(TOTAL_PRESS_NUMBER);
 
 const findTargetChildNode = (element, targetTagName) => {
@@ -37,15 +38,12 @@ const findTargetChildNode = (element, targetTagName) => {
   return null;
 };
 
-const isSubscribed = (pressId) => {
-  return false;
-};
-
 const createNewspaperItem = function (index, mode) {
   const pressId = index + 1;
-  const buttonInner = isSubscribed(pressId)
+  const buttonInner = store.isSubscribed(String(pressId))
     ? unsubscibeButtonInner
     : subscibeButtonInner;
+
   const inner = `<img src="./assets/newspaper/${mode}/${pressId}.png" alt=${"name"} />
   <button class="subscribe-btn" data-key=${pressId}>
   ${buttonInner}

--- a/src/App/Main/MainContent/PressGridView.js
+++ b/src/App/Main/MainContent/PressGridView.js
@@ -1,27 +1,18 @@
 /*
 신문사 컨텐츠 컴포넌트
 */
-
+import findTargetParentNode from "../../../api/findTargetParentNode.js";
 const TOTAL_PRESS_NUMBER = 96;
 const GRID_PRESS_NUBER = 24;
 
 const indexArr = Array.from({ length: TOTAL_PRESS_NUMBER }, (_, i) => i);
 indexArr.sort(() => Math.random() - 0.5);
 
-const findTargetParentNode = (element, targetTagName) => {
-  if (!element) {
-    return null;
-  }
-
-  if (element.tagName === targetTagName) {
-    return element;
-  }
-
-  return findTargetParentNode(element.parentNode, targetTagName);
-};
-
 const findTargetChildNode = (element, targetTagName) => {
   if (!element) return null;
+
+  if (element.tagName.toLowerCase() === targetTagName.toLowerCase())
+    return element;
 
   const children = Array.from(element.children);
 
@@ -38,10 +29,12 @@ const findTargetChildNode = (element, targetTagName) => {
 };
 
 const viewSubscriptionButton = (e) => {
+  if (e.target === e.currentTarget) return;
+
   let target = e.target;
   let img, btn;
 
-  target = findTargetParentNode(target, "LI");
+  target = findTargetParentNode(target, "li");
   img = findTargetChildNode(target, "img");
   btn = findTargetChildNode(target, "button");
 
@@ -49,8 +42,8 @@ const viewSubscriptionButton = (e) => {
   if (btn) btn.style.display = "inline";
 };
 
-const isSubscribed = (pressid) => {
-  return true;
+const isSubscribed = (pressId) => {
+  return false;
 };
 
 const createNewspaperItem = function (index, mode) {
@@ -86,20 +79,7 @@ export default function PressGridView($target, props) {
     const $ul = document.createElement("ul");
 
     $ul.setAttribute("class", "newspaper__list");
-
-    $ul.addEventListener("mouseover", viewSubscriptionButton);
-
     $ul.innerHTML = createPressList(props.currentPage, props.mode);
-
-    $ul.childNodes.forEach((elem) => {
-      elem.addEventListener("mouseout", (e) => {
-        const img = findTargetChildNode(e.target, "img");
-        const btn = findTargetChildNode(e.target, "button");
-
-        if (img) img.style.display = "inline";
-        if (btn) btn.style.display = "none";
-      });
-    });
 
     $target.innerHTML = "";
     $target.appendChild($ul);

--- a/src/App/Main/MainContent/PressGridView.js
+++ b/src/App/Main/MainContent/PressGridView.js
@@ -1,12 +1,21 @@
 /*
 신문사 컨텐츠 컴포넌트
 */
+import getRandomIndexArr from "../../../api/getRandomIndexArr.js";
+import store from "../../../Store/Store.js";
 import findTargetParentNode from "../../../api/findTargetParentNode.js";
+
 const TOTAL_PRESS_NUMBER = 96;
 const GRID_PRESS_NUBER = 24;
 
-const indexArr = Array.from({ length: TOTAL_PRESS_NUMBER }, (_, i) => i);
-indexArr.sort(() => Math.random() - 0.5);
+const subscibeButtonInner = `<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none">
+<path d="M19 12.998H13V18.998H11V12.998H5V10.998H11V4.99799H13V10.998H19V12.998Z" fill="#879298"/>
+</svg>구독하기`;
+
+const unsubscibeButtonInner = `<svg xmlns="http://www.w3.org/2000/svg" width="13" height="12" viewBox="0 0 13 12" fill="none">
+  <path d="M4.26699 9L3.66699 8.4L6.06699 6L3.66699 3.6L4.26699 3L6.66699 5.4L9.06699 3L9.66699 3.6L7.26699 6L9.66699 8.4L9.06699 9L6.66699 6.6L4.26699 9Z" fill="#879298"/>
+  </svg>해지하기`;
+const indexArr = getRandomIndexArr(TOTAL_PRESS_NUMBER);
 
 const findTargetChildNode = (element, targetTagName) => {
   if (!element) return null;
@@ -28,37 +37,23 @@ const findTargetChildNode = (element, targetTagName) => {
   return null;
 };
 
-const viewSubscriptionButton = (e) => {
-  if (e.target === e.currentTarget) return;
-
-  let target = e.target;
-  let img, btn;
-
-  target = findTargetParentNode(target, "li");
-  img = findTargetChildNode(target, "img");
-  btn = findTargetChildNode(target, "button");
-
-  if (img) img.style.display = "none";
-  if (btn) btn.style.display = "inline";
-};
-
 const isSubscribed = (pressId) => {
   return false;
 };
 
 const createNewspaperItem = function (index, mode) {
-  const buttonText = isSubscribed(index + 1) ? "해지하기" : "구독하기";
+  const pressId = index + 1;
+  const buttonInner = isSubscribed(pressId)
+    ? unsubscibeButtonInner
+    : subscibeButtonInner;
+  const inner = `<img src="./assets/newspaper/${mode}/${pressId}.png" alt=${"name"} />
+  <button class="subscribe-btn" data-key=${pressId}>
+  ${buttonInner}
+  </button>`;
 
   return `
-    <li class="newspaper__item">
-    <img src="./assets/newspaper/${mode}/${index + 1}.png" alt=${"name"} />
-    <button class="subscribe-btn" data-key=${
-      index + 1
-    }><svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none">
-    <path d="M19 12.998H13V18.998H11V12.998H5V10.998H11V4.99799H13V10.998H19V12.998Z" fill="#879298"/>
-    </svg>
-    ${buttonText}
-    </button>
+    <li class=${pressId ? "newspaper__item" : "blank"}>
+    ${pressId ? inner : ""}
     </li>
     `;
 };
@@ -68,6 +63,9 @@ const createPressList = function (page, mode) {
     (page - 1) * GRID_PRESS_NUBER,
     page * GRID_PRESS_NUBER
   );
+
+  while (nowPageIndexArr.length < 24) nowPageIndexArr.push(-1);
+
   const liArr = nowPageIndexArr.map((item) => createNewspaperItem(item, mode));
   let pressList = liArr.reduce((news, currentIndex) => news + currentIndex);
 
@@ -81,6 +79,21 @@ export default function PressGridView($target, props) {
     $ul.setAttribute("class", "newspaper__list");
     $ul.innerHTML = createPressList(props.currentPage, props.mode);
 
+    $ul.addEventListener("click", (e) => {
+      let $button;
+      if (e.currentTarget !== e.target) {
+        $button = findTargetChildNode(e.target, "button");
+        console.log($button);
+        store.dispatch($button.innerText, $button.dataset.key);
+
+        $button.innerHTML =
+          $button.innerText === "구독하기"
+            ? unsubscibeButtonInner
+            : subscibeButtonInner;
+
+        console.log(store.myPressList);
+      }
+    });
     $target.innerHTML = "";
     $target.appendChild($ul);
   };

--- a/src/Store/Store.js
+++ b/src/Store/Store.js
@@ -1,0 +1,39 @@
+class Store {
+  #pressArr; // 구독 언론사 배열
+
+  constructor() {
+    this.#pressArr = [];
+  }
+
+  get myPressList() {
+    return this.#pressArr;
+  }
+
+  #subscribe(pressId) {
+    this.#pressArr.push(pressId);
+  }
+
+  #unsubscribe(pressId) {
+    const index = this.#pressArr.indexOf(pressId);
+
+    if (index > -1) {
+      this.#pressArr.splice(index, 1);
+    }
+  }
+
+  isSubscribed(pressId) {
+    return this.#pressArr.indexOf(pressId) > -1;
+  }
+
+  dispatch(type, pressId) {
+    if (type === "구독하기") {
+      this.#subscribe(pressId);
+    } else if (type === "해지하기") {
+      this.#unsubscribe(pressId);
+    }
+  }
+}
+
+const store = new Store();
+
+export default store;

--- a/src/api/fetchNews.js
+++ b/src/api/fetchNews.js
@@ -1,0 +1,7 @@
+const url = "../../listView.json";
+
+async function fetchNews() {
+  return fetch(url).then((response) => response.json());
+}
+
+export default fetchNews;

--- a/src/api/fetchNews.js
+++ b/src/api/fetchNews.js
@@ -1,7 +1,11 @@
-const url = "../../listView.json";
+const listUrl = "../../listView.json";
+const pressUrl = "../../pressData.json";
 
 async function fetchNews() {
-  return fetch(url).then((response) => response.json());
+  return fetch(listUrl).then((response) => response.json());
 }
 
-export default fetchNews;
+async function fetchPress() {
+  return fetch(pressUrl).then((response) => response.json());
+}
+export { fetchNews, fetchPress };

--- a/src/api/findTargetChildNode.js
+++ b/src/api/findTargetChildNode.js
@@ -1,0 +1,21 @@
+const findTargetChildNode = function (element, targetTagName) {
+  if (!element) return null;
+
+  if (element.tagName.toLowerCase() === targetTagName.toLowerCase())
+    return element;
+
+  const children = Array.from(element.children);
+
+  for (const child of children) {
+    if (child.tagName.toLowerCase() === targetTagName.toLowerCase()) {
+      return child;
+    }
+
+    const matchedElement = findTargetChildNode(child, targetTagName);
+    if (matchedElement) return matchedElement;
+  }
+
+  return null;
+};
+
+export default findTargetChildNode;

--- a/src/api/findTargetParentNode.js
+++ b/src/api/findTargetParentNode.js
@@ -1,0 +1,11 @@
+export default function findTargetParentNode(element, targetTagName) {
+  if (!element) {
+    return null;
+  }
+
+  if (element.tagName.toLowerCase() === targetTagName.toLowerCase()) {
+    return element;
+  }
+
+  return findTargetParentNode(element.parentNode, targetTagName);
+}

--- a/src/api/getRandomIndexArr.js
+++ b/src/api/getRandomIndexArr.js
@@ -1,0 +1,6 @@
+export default function getRandomIndexArr(length) {
+  const indexArr = Array.from({ length: length }, (_, i) => i);
+  indexArr.sort(() => Math.random() - 0.5);
+
+  return indexArr;
+}


### PR DESCRIPTION
하나의 HTMLElement로 부터 원하는 자식 element를 찾아내는 함수를 구현하였습니다.

firstChild, lastChild 등 여러 API를 제공하지만 HTML구조에 관계없이 찾고자 하는 태그의 이름만을 입력하면 탐색하여 찾아내는 기능을 만들어 HTML구조의 변화에 유연한 기능을 구현하고 싶었습니다.

```js
/*
* @params {HTMLElement} element 부모요소
* @params {String} targetTagName 찾고자 하는 태그의 이름
*/
const findTargetChildNode = (element, targetTagName) => {
  if (!element) return null;

  const children = Array.from(element.children);

  for (const child of children) {
    if (child.tagName.toLowerCase() === targetTagName.toLowerCase()) {
      return child;
    }

    const matchedElement = findTargetChildNode(child, targetTagName);
    if (matchedElement) return matchedElement;
  }

  return null;
};
```

- [ ] 구독 버튼 공통 컴포넌트 만들기
- [ ] store 구현하기
- [ ] json 데터 리스트뷰에 연동하기