### PR TITLE
[오지은] fe-newsstand 3주차

### DIFF
--- a/constant.js
+++ b/constant.js
@@ -27,6 +27,10 @@ const STATE = {
     IS_GRID: true,
     IS_TOTAL: true,
   },
+  LIST_MODE: {
+    CATE_IDX: 0,
+    MEDIA_IDX: 0,
+  },
 };
 
 export { MEDIA, TOPIC, IMAGE, STATE };

--- a/constant.js
+++ b/constant.js
@@ -1,22 +1,32 @@
-const MEDIA = {
+const MEDIA = Object.freeze({
   TOTAL_NUM: 96,
   GRID_ROW_NUM: 4,
   GRID_COLUMN_NUM: 6,
   MAX_PAGE: 3,
-};
+});
 
-const TOPIC = {
+const TOPIC = Object.freeze({
   TOTAL_NUM: 10,
   SECTION_NUM: 5,
   ROLLING_TIME: 5000,
   ROLLING_TIME_GAP: 1000,
-};
+});
 
-const IMAGE = {
+const IMAGE = Object.freeze({
   BLUE_GRID_ICON: "/images/grid-view_blue.svg",
   GRAY_GRID_ICON: "/images/grid-view_gray.svg",
   BLUE_LIST_ICON: "/images/list-view_blue.svg",
   GRAY_LIST_ICON: "/images/list-view_gray.svg",
+});
+
+const STATE = {
+  GRID_PAGE_NUM: 0,
+  SUBSCRIBE_LIST: [],
+  MODE: {
+    IS_LIGHT: true,
+    IS_GRID: true,
+    IS_TOTAL: true,
+  },
 };
 
-export { MEDIA, TOPIC, IMAGE };
+export { MEDIA, TOPIC, IMAGE, STATE };

--- a/index.html
+++ b/index.html
@@ -73,6 +73,7 @@
                   <li></li>
                   <li></li>
                   <li></li>
+                  <p class="news-list_media_edit" alt="편집 안내 문구"></p>
                 </ul>
               </div>
             </div>

--- a/index.html
+++ b/index.html
@@ -28,8 +28,10 @@
         <!-- 뷰 전환 위한 네비게이터 -->
         <header>
           <nav class="main-nav-left">
-            <h2 class="main-nav_selected">전체 언론사</h2>
-            <h2 class="main-nav_unselected">내가 구독한 언론사</h2>
+            <h2 class="main-nav_total main-nav_selected">전체 언론사</h2>
+            <h2 class="main-nav_subscribe main-nav_unselected">
+              내가 구독한 언론사
+            </h2>
           </nav>
           <nav class="main-nav-right">
             <img

--- a/modules/grid.js
+++ b/modules/grid.js
@@ -3,7 +3,9 @@ import { getJSON } from "./data.js";
 import { shuffleList, setViewEvent } from "./utils.js";
 
 const MEDIA_NUM = MEDIA.GRID_ROW_NUM * MEDIA.GRID_COLUMN_NUM;
+// 전체 언론사 영역
 let idList = Array.from({ length: MEDIA.TOTAL_NUM }, (_, idx) => idx);
+// 내가 구독한 언론사 -> STATE.SUBSCRIBE_LIST
 let mediaInfo;
 
 const $newsWrapper = document.querySelector(".news-grid-wrapper");
@@ -15,8 +17,8 @@ const makeGrid = () => {
   for (let i = 0; i < MEDIA_NUM; i++) {
     const $li = document.createElement("li");
     const imgSrc = STATE.MODE.IS_LIGHT
-      ? `${mediaInfo[i].path_light}`
-      : `${mediaInfo[i].path_dark}`;
+      ? `${mediaInfo[idList[i]].path_light}`
+      : `${mediaInfo[idList[i]].path_dark}`;
 
     const checkImg = new Image();
     checkImg.src = imgSrc;
@@ -100,6 +102,45 @@ const setGridArrowEvent = () => {
   });
 };
 
+const $totalMedia = document.querySelector(".main-nav_total");
+const $subscribeMedia = document.querySelector(".main-nav_subscribe");
+
+/**
+ * 그리드 뷰 내 전체 언론사 / 내가 구독한 언론사 전환 이벤트
+ */
+const setGridModeEvent = () => {
+  $totalMedia.addEventListener("click", () => {
+    if (STATE.MODE.IS_GRID) {
+      onClickGridMode({ className: "main-nav_total" });
+    }
+  });
+  $subscribeMedia.addEventListener("click", () => {
+    if (STATE.MODE.IS_GRID) {
+      onClickGridMode({ className: "main-nav_subscribe" });
+    }
+  });
+};
+
+const onClickGridMode = ({ className }) => {
+  const $selected =
+    className === "main-nav_total" ? $totalMedia : $subscribeMedia;
+  const $unselected =
+    className === "main-nav_total" ? $subscribeMedia : $totalMedia;
+
+  $selected.classList.remove("main-nav_unselected");
+  $selected.classList.add("main-nav_selected");
+
+  $unselected.classList.remove("main-nav_selected");
+  $unselected.classList.add("main-nav_unselected");
+
+  STATE.MODE.IS_TOTAL = $selected === $totalMedia ? true : false;
+  STATE.GRID_PAGE_NUM = 0;
+
+  changeImgSrc(0, MEDIA_NUM);
+  changeButtonView(0, MEDIA_NUM);
+  setArrowVisible();
+};
+
 /**
  * 언론사 이미지 src 변경
  */
@@ -160,10 +201,12 @@ const setArrowVisible = () => {
   // 페이지 제한 0~3에 따른 hidden 여부
   if (STATE.GRID_PAGE_NUM === 0) {
     $leftArrow.classList.add("hidden");
+    $rightArrow.classList.remove("hidden");
   } else if (STATE.GRID_PAGE_NUM > 0 && STATE.GRID_PAGE_NUM < 3) {
     $leftArrow.classList.remove("hidden");
     $rightArrow.classList.remove("hidden");
   } else if (STATE.GRID_PAGE_NUM === 3) {
+    $leftArrow.classList.remove("hidden");
     $rightArrow.classList.add("hidden");
   }
 };
@@ -182,5 +225,6 @@ async function initGridView() {
   setViewEvent();
   makeGrid();
   setGridArrowEvent();
+  setGridModeEvent();
 }
 export { initGridView, setArrowVisible };

--- a/modules/grid.js
+++ b/modules/grid.js
@@ -1,6 +1,6 @@
 import { MEDIA, STATE } from "../constant.js";
 import { getJSON } from "./data.js";
-import { shuffleList, setViewEvent } from "./utils.js";
+import { shuffleList, setViewEvent, onClickSubscribeMode } from "./utils.js";
 
 const MEDIA_NUM = MEDIA.GRID_ROW_NUM * MEDIA.GRID_COLUMN_NUM;
 let idList = Array.from({ length: MEDIA.TOTAL_NUM }, (_, idx) => idx);
@@ -127,18 +127,7 @@ const setGridModeEvent = () => {
  * @param {언론사 토글 중 선택한 클래스 이름} className
  */
 const onClickGridMode = ({ className }) => {
-  const $selected =
-    className === "main-nav_total" ? $totalMedia : $subscribeMedia;
-  const $unselected =
-    className === "main-nav_total" ? $subscribeMedia : $totalMedia;
-
-  $selected.classList.remove("main-nav_unselected");
-  $selected.classList.add("main-nav_selected");
-
-  $unselected.classList.remove("main-nav_selected");
-  $unselected.classList.add("main-nav_unselected");
-
-  STATE.MODE.IS_TOTAL = $selected === $totalMedia ? true : false;
+  onClickSubscribeMode({ className });
   STATE.GRID_PAGE_NUM = 0;
 
   // 모드 재세팅
@@ -263,4 +252,4 @@ async function initGridView() {
   setGridArrowEvent();
   setGridModeEvent();
 }
-export { initGridView, setArrowVisible };
+export { initGridView, setNewPage, setArrowVisible };

--- a/modules/grid.js
+++ b/modules/grid.js
@@ -1,5 +1,4 @@
-import { MEDIA } from "../constant.js";
-import { STATE } from "../state.js";
+import { MEDIA, STATE } from "../constant.js";
 import { shuffleList, setViewEvent } from "./utils.js";
 
 const MEDIA_NUM = MEDIA.GRID_ROW_NUM * MEDIA.GRID_COLUMN_NUM;
@@ -13,7 +12,7 @@ const makeGrid = () => {
 
   for (let i = 0; i < MEDIA_NUM; i++) {
     const $li = document.createElement("li");
-    const imgSrc = STATE.IS_LIGHT
+    const imgSrc = STATE.MODE.IS_LIGHT
       ? `/images/light-media/${idList[i]}.png`
       : `/images/dark-media/${idList[i]}.png`;
 
@@ -39,10 +38,10 @@ const setGridArrowEvent = () => {
   const $rightArrow = document.querySelector(".right-arrow");
 
   $leftArrow.addEventListener("click", () => {
-    if (STATE.IS_GRID) clickArrow(-1);
+    if (STATE.MODE.IS_GRID) clickArrow(-1);
   });
   $rightArrow.addEventListener("click", () => {
-    if (STATE.IS_GRID) clickArrow(+1);
+    if (STATE.MODE.IS_GRID) clickArrow(+1);
   });
 };
 
@@ -57,7 +56,7 @@ const changeImgSrc = () => {
 
   for (let i = 0; i < MEDIA_NUM; i++) {
     const $img = document.querySelector(`.img${i}`);
-    const imgSrc = STATE.IS_LIGHT
+    const imgSrc = STATE.MODE.LIGHT
       ? `./images/light-media/${newImg[i]}.png`
       : `./images/dark-media/${newImg[i]}.png`;
 

--- a/modules/hot-topic.js
+++ b/modules/hot-topic.js
@@ -45,7 +45,7 @@ const rollingTopic = () => {
       rightInterval = null;
 
     clearInterval(leftInterval);
-    clearInterval(leftInterval);
+    clearInterval(rightInterval);
 
     leftInterval = startRolling("hot-topic-left");
 

--- a/modules/list.js
+++ b/modules/list.js
@@ -1,5 +1,5 @@
 import { getJSON } from "./data.js";
-import { shuffleList } from "./utils.js";
+import { onClickSubscribeMode, shuffleList } from "./utils.js";
 import { STATE } from "../constant.js";
 
 let mediaInfo;
@@ -12,6 +12,9 @@ let categoryInfo = {
   "매거진/전문지": [],
   지역: [],
 };
+
+const $totalMedia = document.querySelector(".main-nav_total");
+const $subscribeMedia = document.querySelector(".main-nav_subscribe");
 
 const $categoryBar = document.querySelector(".news-list_category");
 const categoryKeys = Object.keys(categoryInfo);
@@ -193,6 +196,29 @@ const setFullList = () => {
   setProgressBar();
 };
 
+const setListModeEvent = () => {
+  $totalMedia.addEventListener("click", () => {
+    if (!STATE.MODE.IS_GRID) {
+      onClickListMode({ className: "main-nav_total" });
+    }
+  });
+  $subscribeMedia.addEventListener("click", () => {
+    if (!STATE.MODE.IS_GRID) {
+      onClickListMode({ className: "main-nav_subscribe" });
+    }
+  });
+};
+
+/**
+ *
+ * @param {언론사 토글 중 선택한 클래스 이름} className
+ */
+const onClickListMode = ({ className }) => {
+  onClickSubscribeMode({ className });
+  [cateIdx, mediaIdx] = [0, 0];
+  setFullList();
+};
+
 /**
  * 초기 리스트뷰 세팅
  */
@@ -201,6 +227,7 @@ async function initListView() {
   setCategoryBar();
   setFullList();
   setListArrowEvent();
+  setListModeEvent();
 }
 
 export { initListView };

--- a/modules/list.js
+++ b/modules/list.js
@@ -1,6 +1,6 @@
 import { getJSON } from "./data.js";
 import { shuffleList } from "./utils.js";
-import { STATE } from "../state.js";
+import { STATE } from "../constant.js";
 
 let mediaInfo;
 let categoryInfo = {
@@ -43,13 +43,13 @@ const setListArrowEvent = () => {
   const $rightArrow = document.querySelector(".right-arrow");
 
   $leftArrow.addEventListener("click", () => {
-    if (!STATE.IS_GRID) {
+    if (!STATE.MODE.IS_GRID) {
       mediaIdx--;
       setFullList();
     }
   });
   $rightArrow.addEventListener("click", () => {
-    if (!STATE.IS_GRID) {
+    if (!STATE.MODE.IS_GRID) {
       mediaIdx++;
       setFullList();
     }

--- a/modules/utils.js
+++ b/modules/utils.js
@@ -1,11 +1,14 @@
-import { IMAGE, STATE } from "../constant.js";
-import { setArrowVisible } from "./grid.js";
+import { IMAGE, MEDIA, STATE } from "../constant.js";
+import { setArrowVisible, setNewPage } from "./grid.js";
 
 const $gridIcon = document.querySelector(".nav-grid");
 const $listIcon = document.querySelector(".nav-list");
 
 const $gridView = document.querySelector(".news-grid-wrapper");
 const $listView = document.querySelector(".news-list-wrapper");
+
+const $totalMedia = document.querySelector(".main-nav_total");
+const $subscribeMedia = document.querySelector(".main-nav_subscribe");
 
 /**
  * 배열을 섞는 함수
@@ -65,6 +68,11 @@ const moveGridView = () => {
   $listView.classList.add("hidden");
 
   STATE.MODE.IS_GRID = true;
+  const MEDIA_NUM = MEDIA.GRID_ROW_NUM * MEDIA.GRID_COLUMN_NUM;
+  setNewPage(
+    STATE.GRID_PAGE_NUM * MEDIA_NUM,
+    (STATE.GRID_PAGE_NUM + 1) * MEDIA_NUM
+  );
   setArrowVisible();
 };
 
@@ -88,6 +96,28 @@ const moveListView = () => {
 };
 
 /**
+ *
+ * @param {언론사 토글 중 선택한 클래스 이름} className
+ */
+const onClickSubscribeMode = ({ className }) => {
+  const $selected =
+    className === "main-nav_total" ? $totalMedia : $subscribeMedia;
+  const $unselected =
+    className === "main-nav_total" ? $subscribeMedia : $totalMedia;
+
+  $selected.classList.remove("main-nav_unselected");
+  $selected.classList.add("main-nav_selected");
+
+  $unselected.classList.remove("main-nav_selected");
+  $unselected.classList.add("main-nav_unselected");
+
+  STATE.MODE.IS_TOTAL = $selected === $totalMedia ? true : false;
+
+  // 전체 언론사 -> 그리드 / 내가 구독한 언론사 -> 리스트뷰 디폴트
+  className === "main-nav_total" ? moveGridView() : moveListView();
+};
+
+/**
  * 헤더의 공통뷰를 세팅하는 함수
  */
 async function initCommonView() {
@@ -95,4 +125,11 @@ async function initCommonView() {
   setDate();
 }
 
-export { initCommonView, shuffleList, setDate, setReload, setViewEvent };
+export {
+  initCommonView,
+  shuffleList,
+  setDate,
+  setReload,
+  setViewEvent,
+  onClickSubscribeMode,
+};

--- a/modules/utils.js
+++ b/modules/utils.js
@@ -1,5 +1,4 @@
-import { IMAGE } from "../constant.js";
-import { STATE } from "../state.js";
+import { IMAGE, STATE } from "../constant.js";
 import { setArrowVisible } from "./grid.js";
 
 const $gridIcon = document.querySelector(".nav-grid");
@@ -65,7 +64,7 @@ const moveGridView = () => {
   $gridView.classList.remove("hidden");
   $listView.classList.add("hidden");
 
-  STATE.IS_GRID = true;
+  STATE.MODE.IS_GRID = true;
   setArrowVisible();
 };
 
@@ -85,7 +84,7 @@ const moveListView = () => {
   $leftArrow.classList.remove("hidden");
   $rightArrow.classList.remove("hidden");
 
-  STATE.IS_GRID = false;
+  STATE.MODE.IS_GRID = false;
 };
 
 /**

--- a/state.js
+++ b/state.js
@@ -1,7 +1,0 @@
-let STATE = {
-  GRID_PAGE_NUM: 0,
-  IS_LIGHT: true,
-  IS_GRID: true,
-};
-
-export { STATE };

--- a/styles/grid.css
+++ b/styles/grid.css
@@ -14,9 +14,69 @@
   display: flex;
   justify-content: center;
   align-items: center;
+
+  position: relative;
+
   width: 154px;
   height: 96px;
+
   list-style-type: none;
   border-right: 1px solid #d2dae0;
   border-bottom: 1px solid #d2dae0;
+}
+
+.news-grid-wrapper > li:hover .news-grid_button_wrapper {
+  display: flex;
+}
+
+.news-grid_button_wrapper {
+  display: none;
+  justify-content: center;
+  align-items: center;
+
+  width: 154px;
+  height: 96px;
+
+  position: absolute;
+  top: 0;
+  left: 0;
+
+  background-color: var(--grayscale-50);
+}
+
+.news-grid_unsubscribed_btn {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  height: 24px;
+  padding: 0px 6px;
+  gap: 2px;
+
+  color: var(--grayscale-200);
+  border-radius: 50px;
+  border: 1px solid var(--grayscale-100);
+  background-color: var(--grayscale-white);
+
+  &:hover {
+    cursor: pointer;
+  }
+}
+
+.news-grid_subscribed_btn {
+  display: flex;
+  height: 24px;
+  padding: 0px 6px;
+  justify-content: center;
+  align-items: center;
+  gap: 2px;
+
+  color: var(--grayscale-200);
+  border-radius: 50px;
+  border: 1px solid var(--grayscale-100);
+  background-color: var(--grayscale-50);
+
+  &:hover {
+    cursor: pointer;
+  }
 }

--- a/styles/list.css
+++ b/styles/list.css
@@ -98,7 +98,7 @@
 .news-list_unsubscribed_btn {
   display: flex;
   height: 24px;
-  padding: 0px 6px;
+  padding: 6px;
   justify-content: center;
   align-items: center;
   gap: 2px;
@@ -159,4 +159,9 @@
   &:hover {
     text-decoration: underline;
   }
+}
+
+.news-list_media_edit {
+  font: var(--medium-R);
+  color: var(--grayscale-200);
 }


### PR DESCRIPTION
### 📌 Issue
1. JeeeunOh#5
2. JeeeunOh#6
3. JeeeunOh#7
4. JeeeunOh#8

### 📌 고민했던 내용

전체 언론사 / 내가 구독한 언론사 뷰를 전환시에, 어떻게 이벤트 함수를 공통화해서 그리드뷰와 리스트뷰에 공통으로 쓸 수 있을지 고민하였습니다.

이에, 다음과 같이 함수를 작성하여 전체 언론사 선택 시에 그리드뷰를 디폴트로, 내가 구독한 언론사 선택 시에 리스트뷰를 디폴트로 이동하는 이벤트 함수를 구현하였습니다.

```js
const onClickSubscribeMode = ({ className }) => {
  const $selected =
    className === "main-nav_total" ? $totalMedia : $subscribeMedia;
  const $unselected =
    className === "main-nav_total" ? $subscribeMedia : $totalMedia;

  $selected.classList.remove("main-nav_unselected");
  $selected.classList.add("main-nav_selected");

  $unselected.classList.remove("main-nav_selected");
  $unselected.classList.add("main-nav_unselected");

  STATE.MODE.IS_TOTAL = $selected === $totalMedia ? true : false;

  // 전체 언론사 -> 그리드 / 내가 구독한 언론사 -> 리스트뷰 디폴트
  className === "main-nav_total" ? moveGridView() : moveListView();
};
```

또한, 해당 함수를 각각 grid.js / list.js 에서 호출하여 공통으로 이벤트 함수를 사용하고 공통화하기에 어려운 각 모드들의 상태들은 각 함수 내에서 따로 재설정해주었습니다.

- grid.js

```js
const onClickGridMode = ({ className }) => {
  onClickSubscribeMode({ className });
  STATE.GRID_PAGE_NUM = 0;

  // 모드 재세팅
  setNewPage(0, MEDIA_NUM);
  setArrowVisible();
};
```

- list.js
```js
const onClickListMode = ({ className }) => {
  onClickSubscribeMode({ className });
  [STATE.LIST_MODE.CATE_IDX, STATE.LIST_MODE.MEDIA_IDX] = [0, 0];
  setFullList();
};
```