### PR TITLE
[오지은] fe-newsstand 4주차

### DIFF
--- a/assets/media-content.json
+++ b/assets/media-content.json
@@ -2109,49 +2109,5 @@
       "한국의 블록체인 기술, 신뢰와 투명성을 위한 혁신"
     ],
     "is_subscribe": "false"
-  },
-
-  {
-    "id": "97",
-    "name": "undefined",
-    "path_light": "/images/light-media/96.png",
-    "path_dark": "/images/dark-media/96.png",
-    "category": "매거진/전문지",
-    "thumbnail": "/images/thumbnail/thumbnail97.jpg",
-    "edit_date": "2023.07.10. 18:34",
-    "main_title": "한국의 첨단 제조업, 스마트 팩토리 구축으로 생산성 향상",
-    "main_img_src": "/images/96.png",
-    "sub_title": [
-      "한국의 음악 씬, 한류의 새로운 레지던스",
-      "한국의 사이버 보안, 빠르게 진화하는 위협에 대응",
-      "한국의 공공 건강 관리, 예방 중심의 혁신적인 정책 추진",
-      "한국의 미디어 산업, 디지털 플랫폼 시대의 선두주자",
-      "한국의 스마트 시티 구축, 효율적인 도시 관리의 표본",
-      "한국의 블록체인 기술, 신뢰와 투명성을 위한 혁신",
-      "한국의 미술 산업, 창의적인 예술 작품으로 세계를 감동시키다"
-    ],
-    "is_subscribe": "false"
-  },
-
-  {
-    "id": "98",
-    "name": "undefined",
-    "path_light": "/images/light-media/97.png",
-    "path_dark": "/images/dark-media/97.png",
-    "category": "지역",
-    "thumbnail": "/images/thumbnail/thumbnail98.jpg",
-    "edit_date": "2023.07.10. 18:34",
-    "main_title": "한국의 교육 혁신, 창의적인 학습 방법으로 글로벌 경쟁력 강화",
-    "main_img_src": "/images/97.png",
-    "sub_title": [
-      "한국의 사이버 보안, 빠르게 진화하는 위협에 대응",
-      "한국의 공공 건강 관리, 예방 중심의 혁신적인 정책 추진",
-      "한국의 미디어 산업, 디지털 플랫폼 시대의 선두주자",
-      "한국의 스마트 시티 구축, 효율적인 도시 관리의 표본",
-      "한국의 블록체인 기술, 신뢰와 투명성을 위한 혁신",
-      "한국의 미술 산업, 창의적인 예술 작품으로 세계를 감동시키다",
-      "한국의 해양 산업, 바다의 자원을 지속 가능하게 관리"
-    ],
-    "is_subscribe": "false"
   }
 ]

--- a/constant.js
+++ b/constant.js
@@ -26,20 +26,4 @@ const MESSAGE = Object.freeze({
   ERROR_NO_SUBSCRIBE: "구독중인 언론사가 없습니다!",
 });
 
-const STATE = {
-  GRID_PAGE_NUM: 0,
-  SUBSCRIBE_LIST: [],
-  SELECT_SUBSCRIBE_IDX: 0,
-  MODE: {
-    IS_LIGHT: true,
-    IS_GRID: true,
-    IS_TOTAL: true,
-  },
-  LIST_MODE: {
-    CATE_IDX: 0,
-    CATE_MEDIA_IDX: 0,
-    SUBSCRIBE_MEDIA_IDX: 0,
-  },
-};
-
-export { MEDIA, TOPIC, IMAGE, MESSAGE, STATE };
+export { MEDIA, TOPIC, IMAGE, MESSAGE };

--- a/constant.js
+++ b/constant.js
@@ -21,17 +21,14 @@ const IMAGE = Object.freeze({
   GRAY_LIST_ICON: "/images/list-view_gray.svg",
 });
 
-const MESSAGE = {
+const MESSAGE = Object.freeze({
   UNSUBSCRIBE: "구독이 해지되었습니다!",
   ERROR_NO_SUBSCRIBE: "구독중인 언론사가 없습니다!",
-};
+});
 
 const STATE = {
   GRID_PAGE_NUM: 0,
-  SUBSCRIBE_LIST: [
-    0, 10, 18, 3, 15, 9, 24, 5, 6, 7, 8, 13, 14, 31, 15, 38, 56, 80, 90, 57, 49,
-    35,
-  ],
+  SUBSCRIBE_LIST: [],
   SELECT_SUBSCRIBE_IDX: 0,
   MODE: {
     IS_LIGHT: true,

--- a/modules/grid.js
+++ b/modules/grid.js
@@ -1,9 +1,9 @@
-import { MEDIA, MESSAGE, STATE } from "../constant.js";
+import { MEDIA, MESSAGE } from "../constant.js";
 import { getJSON } from "./data.js";
 import { shuffleList } from "./utils.js";
 import { onClickSubscribeMode, changeSubState } from "./subscribe.js";
-import { getState, register, setState } from "../observer/observer.js";
-import { gridPageNum, isLightMode } from "../store/index.js";
+import { getState, setState } from "../observer/observer.js";
+import { isLightMode } from "../store/index.js";
 
 const MEDIA_NUM = MEDIA.GRID_ROW_NUM * MEDIA.GRID_COLUMN_NUM;
 let idList = Array.from({ length: MEDIA.TOTAL_NUM }, (_, idx) => idx);
@@ -46,17 +46,17 @@ const makeGrid = () => {
 const addSubscribeButton = (idx) => {
   const mediaId = getState("isTotalMode")
     ? idList[idx]
-    : STATE.SUBSCRIBE_LIST[idx];
+    : getState("subscribeList")[idx];
   const $buttonWrapper = document.createElement("div");
   $buttonWrapper.classList.add("news-grid_button_wrapper");
 
   const $button = document.createElement("button");
   $button.classList.add(
-    STATE.SUBSCRIBE_LIST.includes(mediaId)
+    getState("subscribeList").includes(mediaId)
       ? "news-grid_subscribed_btn"
       : "news-grid_unsubscribed_btn"
   );
-  $button.innerText = STATE.SUBSCRIBE_LIST.includes(mediaId)
+  $button.innerText = getState("subscribeList").includes(mediaId)
     ? "x 해지하기"
     : "+ 구독하기";
 
@@ -76,7 +76,7 @@ const addSubscribeButton = (idx) => {
 const clickSubButton = (idx) => {
   const mediaId = getState("isTotalMode")
     ? idList[idx]
-    : STATE.SUBSCRIBE_LIST[idx];
+    : getState("subscribeList")[idx];
   const mediaName = mediaInfo[mediaId].name;
 
   changeSubState({ mediaId, mediaName });
@@ -97,10 +97,10 @@ const setGridArrowEvent = () => {
   const $rightArrow = document.querySelector(".right-arrow");
 
   $leftArrow.addEventListener("click", () => {
-    if (STATE.MODE.IS_GRID) clickArrow(-1);
+    if (getState("isGridMode")) clickArrow(-1);
   });
   $rightArrow.addEventListener("click", () => {
-    if (STATE.MODE.IS_GRID) clickArrow(+1);
+    if (getState("isGridMode")) clickArrow(+1);
   });
 };
 
@@ -109,12 +109,12 @@ const setGridArrowEvent = () => {
  */
 const setGridModeEvent = () => {
   $totalMedia.addEventListener("click", () => {
-    if (STATE.MODE.IS_GRID) {
+    if (getState("isGridMode")) {
       onClickGridMode({ className: "main-nav_total" });
     }
   });
   $subscribeMedia.addEventListener("click", () => {
-    if (STATE.MODE.IS_GRID) {
+    if (getState("isGridMode")) {
       onClickGridMode({ className: "main-nav_subscribe" });
     }
   });
@@ -133,7 +133,7 @@ const onClickGridMode = ({ className }) => {
  * 페이지 전환 / 모드 전환 시 새로운 페이지 세팅
  */
 const setNewPage = () => {
-  if (!getState("isTotalMode") && STATE.SUBSCRIBE_LIST.length === 0) {
+  if (!getState("isTotalMode") && getState("subscribeList").length === 0) {
     alert(MESSAGE.ERROR_NO_SUBSCRIBE);
     onClickSubscribeMode({ className: "main-nav_total" });
     return;
@@ -152,7 +152,7 @@ const changeImgSrc = () => {
   for (let i = start; i < start + MEDIA_NUM; i++) {
     const mediaIdx = getState("isTotalMode")
       ? idList[i]
-      : STATE.SUBSCRIBE_LIST[i];
+      : getState("subscribeList")[i];
 
     const $img = document.querySelector(`.img${i - start}`);
     const $buttonWrapper = $img.nextSibling;
@@ -165,7 +165,7 @@ const changeImgSrc = () => {
 
     $buttonWrapper.style.display = "";
 
-    const imgSrc = STATE.MODE.IS_LIGHT
+    const imgSrc = getState("isLightMode")
       ? `${mediaInfo[mediaIdx].path_light}`
       : `${mediaInfo[mediaIdx].path_dark}`;
 
@@ -225,7 +225,7 @@ const setArrowVisible = () => {
   // 미디어 개수에 따른 hidden 여부
   const totalPage = getState("isTotalMode")
     ? idList.length / MEDIA_NUM
-    : STATE.SUBSCRIBE_LIST.length / MEDIA_NUM;
+    : getState("subscribeList").length / MEDIA_NUM;
 
   if (getState("gridPageNum") < totalPage - 1) {
     $rightArrow.classList.remove("hidden");
@@ -244,9 +244,6 @@ const getGridInfo = async () => {
 async function initGridView() {
   await getGridInfo();
   idList = shuffleList(idList);
-  register(isLightMode, makeGrid);
-  register(gridPageNum, changeButtonView);
-  register(gridPageNum, changeImgSrc);
 
   makeGrid();
   setArrowVisible();

--- a/modules/grid.js
+++ b/modules/grid.js
@@ -30,7 +30,7 @@ const makeGrid = () => {
     $img.style.height = "20px";
     $li.appendChild($img);
 
-    const $buttonWrapper = addSubscribeButton(i);
+    const $buttonWrapper = setButttonWrapper(i);
     $li.append($buttonWrapper);
     $newsWrapper.append($li);
   }
@@ -49,52 +49,41 @@ const changeImgSrc = () => {
       ? idList[i]
       : getState(subscribeList)[i];
 
-    const $Wrapper = $newsWrapper.childNodes[i - start];
-    const $buttonWrapper = $Wrapper.querySelector(".news-grid_button_wrapper");
     const $img = document.querySelector(`.img${i - start}`);
 
     if (mediaIdx === undefined) {
       $img.src = "";
-      $buttonWrapper.style.display = "none";
       continue;
     }
-
-    $buttonWrapper.style.display = "";
 
     const imgSrc = getState(isLightMode)
       ? `${mediaInfo[mediaIdx].path_light}`
       : `${mediaInfo[mediaIdx].path_dark}`;
-    // $img.src = imgSrc;
-
-    const checkImg = new Image();
-    checkImg.src = imgSrc;
-    checkImg.onload = () => {
-      $img.src = imgSrc;
-    };
-    checkImg.onerror = () => {
-      $img.src = "";
-      $buttonWrapper.style.display = "none";
-    };
+    $img.src = imgSrc;
   }
 };
 
 /**
  * 구독 버튼 영역 추가
  */
-const addSubscribeButton = (idx) => {
-  const mediaId = getState("isTotalMode")
+const setButttonWrapper = (idx) => {
+  const mediaId = getState(isTotalMode)
     ? idList[idx]
-    : getState("subscribeList")[idx];
+    : getState(subscribeList)[idx];
   const $buttonWrapper = document.createElement("div");
   $buttonWrapper.classList.add("news-grid_button_wrapper");
 
+  const mediaIdx = getState(isTotalMode)
+    ? idList[idx]
+    : getState(subscribeList)[idx];
+
   const $button = document.createElement("button");
   $button.classList.add(
-    getState("subscribeList").includes(mediaId)
+    getState(subscribeList).includes(mediaId)
       ? "news-grid_subscribed_btn"
       : "news-grid_unsubscribed_btn"
   );
-  $button.innerText = getState("subscribeList").includes(mediaId)
+  $button.innerText = getState(subscribeList).includes(mediaId)
     ? "x 해지하기"
     : "+ 구독하기";
 
@@ -103,6 +92,12 @@ const addSubscribeButton = (idx) => {
   });
 
   $buttonWrapper.append($button);
+
+  if (mediaIdx === undefined) {
+    $buttonWrapper.style.display = "none";
+  } else {
+    $buttonWrapper.style.display = "";
+  }
 
   return $buttonWrapper;
 };
@@ -124,7 +119,7 @@ const clickSubButton = (idx) => {
   );
 
   $buttonWrapper.remove();
-  $newsWrapper.children[idx % MEDIA_NUM].append(addSubscribeButton(idx));
+  $newsWrapper.children[idx % MEDIA_NUM].append(setButttonWrapper(idx));
 };
 
 /**
@@ -190,7 +185,7 @@ const changeButtonView = () => {
   $newsList.forEach((li, idx) => {
     const $buttonWrapper = li.querySelector(".news-grid_button_wrapper");
     $buttonWrapper.remove();
-    li.append(addSubscribeButton(start + idx));
+    li.append(setButttonWrapper(start + idx));
   });
 };
 
@@ -238,18 +233,22 @@ const getGridInfo = async () => {
   mediaInfo = await getJSON("/assets/media-content.json");
 };
 
-/**
- * 초기 그리드뷰 세팅
- */
-async function initGridView() {
-  await getGridInfo();
-  idList = shuffleList(idList);
-
+const initGridRegister = () => {
   register(
     [gridPageNum, isTotalMode, subscribeList, isLightMode],
     changeImgSrc
   );
+  register([isTotalMode, subscribeList], setButttonWrapper);
+};
 
+/**
+ * 초기 그리드뷰 세팅
+ */
+async function initGridView() {
+  initGridRegister();
+
+  await getGridInfo();
+  idList = shuffleList(idList);
   makeGrid();
   setArrowVisible();
   setGridArrowEvent();

--- a/modules/grid.js
+++ b/modules/grid.js
@@ -2,8 +2,8 @@ import { MEDIA, MESSAGE } from "../constant.js";
 import { getJSON } from "./data.js";
 import { shuffleList } from "./utils.js";
 import { onClickSubscribeMode, changeSubState } from "./subscribe.js";
-import { getState, setState } from "../observer/observer.js";
-import { isLightMode } from "../store/index.js";
+import { getState, register, setState } from "../observer/observer.js";
+import { isGridMode, isLightMode } from "../store/index.js";
 
 const MEDIA_NUM = MEDIA.GRID_ROW_NUM * MEDIA.GRID_COLUMN_NUM;
 let idList = Array.from({ length: MEDIA.TOTAL_NUM }, (_, idx) => idx);
@@ -97,10 +97,10 @@ const setGridArrowEvent = () => {
   const $rightArrow = document.querySelector(".right-arrow");
 
   $leftArrow.addEventListener("click", () => {
-    if (getState("isGridMode")) clickArrow(-1);
+    if (getState(isGridMode)) clickArrow(-1);
   });
   $rightArrow.addEventListener("click", () => {
-    if (getState("isGridMode")) clickArrow(+1);
+    if (getState(isGridMode)) clickArrow(+1);
   });
 };
 
@@ -109,12 +109,12 @@ const setGridArrowEvent = () => {
  */
 const setGridModeEvent = () => {
   $totalMedia.addEventListener("click", () => {
-    if (getState("isGridMode")) {
+    if (getState(isGridMode)) {
       onClickGridMode({ className: "main-nav_total" });
     }
   });
   $subscribeMedia.addEventListener("click", () => {
-    if (getState("isGridMode")) {
+    if (getState(isGridMode)) {
       onClickGridMode({ className: "main-nav_subscribe" });
     }
   });

--- a/modules/list.js
+++ b/modules/list.js
@@ -2,7 +2,8 @@ import { MESSAGE } from "../constant.js";
 import { getJSON } from "./data.js";
 import { shuffleList } from "./utils.js";
 import { onClickSubscribeMode, changeSubState } from "./subscribe.js";
-import { getState, setState } from "../observer/observer.js";
+import { getState, register, setState } from "../observer/observer.js";
+import { isGridMode, isTotalMode } from "../store/mode.js";
 
 let mediaInfo;
 let categoryInfo = {
@@ -53,8 +54,8 @@ const setListArrowEvent = () => {
   const $rightArrow = document.querySelector(".right-arrow");
 
   $leftArrow.addEventListener("click", () => {
-    if (!getState("isGridMode")) {
-      if (getState("isTotalMode")) {
+    if (!getState(isGridMode)) {
+      if (getState(isTotalMode)) {
         setState("listCateMediaIdx", getState("listCateMediaIdx") - 1);
       } else {
         setState("listSubsMediaIdx", getState("listSubsMediaIdx") - 1);
@@ -63,8 +64,8 @@ const setListArrowEvent = () => {
     }
   });
   $rightArrow.addEventListener("click", () => {
-    if (!getState("isGridMode")) {
-      if (getState("isTotalMode")) {
+    if (!getState(isGridMode)) {
+      if (getState(isTotalMode)) {
         setState("listCateMediaIdx", getState("listCateMediaIdx") + 1);
       } else {
         setState("listSubsMediaIdx", getState("listSubsMediaIdx") + 1);
@@ -342,6 +343,9 @@ const setFullList = () => {
  */
 async function initListView() {
   await getListInfo();
+
+  // register([isGridMode, isTotalMode], setListArrowEvent);
+
   setListArrowEvent();
   setListModeEvent();
   setListSubscribeEvent();

--- a/modules/list.js
+++ b/modules/list.js
@@ -2,6 +2,7 @@ import { MESSAGE, STATE } from "../constant.js";
 import { getJSON } from "./data.js";
 import { shuffleList } from "./utils.js";
 import { onClickSubscribeMode, changeSubState } from "./subscribe.js";
+import { getState } from "../observer/observer.js";
 
 let mediaInfo;
 let categoryInfo = {
@@ -53,14 +54,14 @@ const setListArrowEvent = () => {
 
   $leftArrow.addEventListener("click", () => {
     if (!STATE.MODE.IS_GRID) {
-      if (STATE.MODE.IS_TOTAL) STATE.LIST_MODE.CATE_MEDIA_IDX--;
+      if (getState("isTotalMode")) STATE.LIST_MODE.CATE_MEDIA_IDX--;
       else STATE.LIST_MODE.SUBSCRIBE_MEDIA_IDX--;
       setFullList();
     }
   });
   $rightArrow.addEventListener("click", () => {
     if (!STATE.MODE.IS_GRID) {
-      if (STATE.MODE.IS_TOTAL) STATE.LIST_MODE.CATE_MEDIA_IDX++;
+      if (getState("isTotalMode")) STATE.LIST_MODE.CATE_MEDIA_IDX++;
       else STATE.LIST_MODE.SUBSCRIBE_MEDIA_IDX++;
       setFullList();
     }
@@ -109,7 +110,7 @@ const clickSubButton = () => {
       STATE.LIST_MODE.CATE_MEDIA_IDX
     ];
   const subsId = STATE.SUBSCRIBE_LIST[STATE.LIST_MODE.SUBSCRIBE_MEDIA_IDX];
-  const mediaId = STATE.MODE.IS_TOTAL ? totalId : subsId;
+  const mediaId = getState("isTotalMode") ? totalId : subsId;
   const mediaName = mediaInfo[mediaId].name;
   changeSubState({ mediaId, mediaName });
 };
@@ -120,7 +121,7 @@ const clickSubButton = () => {
 const changeIdx = () => {
   let cateLen = categoryInfo[categoryKeys[STATE.LIST_MODE.CATE_IDX]].length;
 
-  if (STATE.MODE.IS_TOTAL) {
+  if (getState("isTotalMode")) {
     if (
       STATE.LIST_MODE.CATE_IDX === 0 &&
       STATE.LIST_MODE.CATE_MEDIA_IDX === -1
@@ -152,7 +153,7 @@ const changeIdx = () => {
       STATE.LIST_MODE.CATE_IDX++;
       STATE.LIST_MODE.CATE_MEDIA_IDX = 0;
     }
-  } else if (!STATE.MODE.IS_TOTAL) {
+  } else if (!getState("isTotalMode")) {
     if (STATE.LIST_MODE.SUBSCRIBE_MEDIA_IDX === -1) {
       STATE.LIST_MODE.SUBSCRIBE_MEDIA_IDX = STATE.SUBSCRIBE_LIST.length - 1;
     } else if (
@@ -169,7 +170,7 @@ const changeIdx = () => {
  */
 const setCategoryBar = () => {
   $categoryBar.innerHTML = "";
-  if (STATE.MODE.IS_TOTAL) {
+  if (getState("isTotalMode")) {
     setACategoryBar({ keyList: categoryKeys });
   } else {
     const subMediaName = STATE.SUBSCRIBE_LIST.map(
@@ -183,7 +184,7 @@ const setCategoryBar = () => {
  * @returns 현재 카테고리인지 여부
  */
 const isCurCategory = ({ cateIdx }) => {
-  if (STATE.MODE.IS_TOTAL) {
+  if (getState("isTotalMode")) {
     // 전체모드일 때
     return STATE.LIST_MODE.CATE_IDX === cateIdx;
   } else {
@@ -200,7 +201,7 @@ const setACategoryBar = ({ keyList }) => {
     const $li = document.createElement("li");
     $li.addEventListener("click", () => {
       if (isCurCategory({ cateIdx: idx })) return;
-      if (STATE.MODE.IS_TOTAL) {
+      if (getState("isTotalMode")) {
         STATE.LIST_MODE.CATE_IDX = idx;
         STATE.LIST_MODE.CATE_MEDIA_IDX = 0;
       } else {
@@ -236,14 +237,14 @@ const setProgressBar = () => {
   });
 
   // 2. 모드 따라 현재 선택한 카테고리 위치에 프로그래스바 추가
-  const curCateIdx = STATE.MODE.IS_TOTAL
+  const curCateIdx = getState("isTotalMode")
     ? STATE.LIST_MODE.CATE_IDX
     : STATE.LIST_MODE.SUBSCRIBE_MEDIA_IDX;
   const $li = $categoryBar.children[curCateIdx];
   $li.className = "category_selected";
 
   const $cntDiv = $li.children[1];
-  if (STATE.MODE.IS_TOTAL) {
+  if (getState("isTotalMode")) {
     // 2-1. 전체 언론사 모드일 때만 카운트 추가
     $cntDiv.innerHTML = `
   <p>${STATE.LIST_MODE.CATE_MEDIA_IDX + 1}</p>
@@ -261,7 +262,7 @@ const setProgressBar = () => {
   $li.append($progressBar);
 
   $progressBar.addEventListener("animationend", () => {
-    if (STATE.MODE.IS_TOTAL) STATE.LIST_MODE.CATE_MEDIA_IDX++;
+    if (getState("isTotalMode")) STATE.LIST_MODE.CATE_MEDIA_IDX++;
     else STATE.LIST_MODE.SUBSCRIBE_MEDIA_IDX++;
     setFullList();
   });
@@ -274,7 +275,7 @@ const setListView = () => {
   const cate = categoryKeys[STATE.LIST_MODE.CATE_IDX];
 
   // 모드에 따라 mediaId 세팅
-  const mediaId = STATE.MODE.IS_TOTAL
+  const mediaId = getState("isTotalMode")
     ? categoryInfo[cate][STATE.LIST_MODE.CATE_MEDIA_IDX]
     : STATE.SUBSCRIBE_LIST[STATE.LIST_MODE.SUBSCRIBE_MEDIA_IDX];
 
@@ -310,7 +311,7 @@ const setListView = () => {
  * 프로그래스바, 뉴스영역 렌더링
  */
 const setFullList = () => {
-  if (!STATE.MODE.IS_TOTAL && STATE.SUBSCRIBE_LIST.length === 0) {
+  if (!getState("isTotalMode") && STATE.SUBSCRIBE_LIST.length === 0) {
     alert(MESSAGE.ERROR_NO_SUBSCRIBE);
     onClickSubscribeMode({ className: "main-nav_total" });
     return;

--- a/modules/subscribe.js
+++ b/modules/subscribe.js
@@ -1,4 +1,3 @@
-import { STATE } from "../constant.js";
 import { moveGridView, moveListView } from "./utils.js";
 import { getState, setState } from "../observer/observer.js";
 
@@ -32,19 +31,19 @@ const onClickSubscribeMode = ({ className }) => {
 };
 
 const changeSubState = ({ mediaId, mediaName }) => {
-  const subIdx = STATE.SUBSCRIBE_LIST.indexOf(mediaId);
-  STATE.SELECT_SUBSCRIBE_IDX = subIdx;
+  const subIdx = getState("subscribeList").indexOf(mediaId);
+  setState("selectSubscribeIdx", subIdx);
 
   if (subIdx !== -1) {
     $subAlertName.innerText = mediaName;
     $subsAlert.classList.remove("hidden");
   } else {
-    STATE.SUBSCRIBE_LIST = [...STATE.SUBSCRIBE_LIST, mediaId];
+    setState("subscribeList", [...getState("subscribeList"), mediaId]);
 
     $snackBar.classList.remove("hidden");
     setTimeout(() => {
       $snackBar.classList.add("hidden");
-      STATE.LIST_MODE.SUBSCRIBE_MEDIA_IDX = STATE.SUBSCRIBE_LIST.length - 1;
+      setState("listSubsMediaIdx", getState("subscribeList").length - 1);
       onClickSubscribeMode({ className: "main-nav_subscribe" });
     }, 1000);
   }

--- a/modules/subscribe.js
+++ b/modules/subscribe.js
@@ -1,5 +1,6 @@
 import { STATE } from "../constant.js";
 import { moveGridView, moveListView } from "./utils.js";
+import { getState, setState } from "../observer/observer.js";
 
 const $totalMedia = document.querySelector(".main-nav_total");
 const $subscribeMedia = document.querySelector(".main-nav_subscribe");
@@ -24,7 +25,7 @@ const onClickSubscribeMode = ({ className }) => {
   $unselected.classList.remove("main-nav_selected");
   $unselected.classList.add("main-nav_unselected");
 
-  STATE.MODE.IS_TOTAL = $selected === $totalMedia;
+  setState("isTotalMode", $selected === $totalMedia);
 
   // 전체 언론사 -> 그리드 / 내가 구독한 언론사 -> 리스트뷰 디폴트
   className === "main-nav_total" ? moveGridView() : moveListView();

--- a/modules/utils.js
+++ b/modules/utils.js
@@ -1,4 +1,5 @@
 import { IMAGE, MEDIA, MESSAGE, STATE } from "../constant.js";
+import { setState } from "../observer/observer.js";
 import { changeImgSrc, setNewPage } from "./grid.js";
 import { setCategoryBar, setFullList, setListView } from "./list.js";
 
@@ -28,12 +29,12 @@ const setColorModeEvent = () => {
 
   $colorModeBtn.addEventListener("click", () => {
     $html.classList.toggle("dark");
-    STATE.MODE.IS_LIGHT = !STATE.MODE.IS_LIGHT;
+
+    setState("isLightMode", $html.className !== "dark");
+
     $colorModeBtn.src =
       $html.className === "dark" ? IMAGE.SUN_ICON : IMAGE.MOON_ICON;
-    STATE.MODE.IS_GRID
-      ? changeImgSrc(MEDIA_NUM * STATE.GRID_PAGE_NUM)
-      : setListView();
+    STATE.MODE.IS_GRID ? changeImgSrc() : setListView();
   });
 };
 /**
@@ -87,10 +88,7 @@ const moveGridView = () => {
 
   STATE.MODE.IS_GRID = true;
   const MEDIA_NUM = MEDIA.GRID_ROW_NUM * MEDIA.GRID_COLUMN_NUM;
-  setNewPage(
-    STATE.GRID_PAGE_NUM * MEDIA_NUM,
-    (STATE.GRID_PAGE_NUM + 1) * MEDIA_NUM
-  );
+  setNewPage();
 };
 
 /**
@@ -129,10 +127,7 @@ const initSubsModalView = () => {
 
     if (STATE.MODE.IS_GRID) {
       const MEDIA_NUM = MEDIA.GRID_ROW_NUM * MEDIA.GRID_COLUMN_NUM;
-      setNewPage(
-        STATE.GRID_PAGE_NUM * MEDIA_NUM,
-        (STATE.GRID_PAGE_NUM + 1) * MEDIA_NUM
-      );
+      setNewPage();
     } else {
       setCategoryBar();
       setFullList();
@@ -146,7 +141,7 @@ const initSubsModalView = () => {
 /**
  * 공통뷰 & 공통 이벤트 세팅
  */
-async function initCommonView() {
+function initCommonView() {
   setColorModeEvent();
   setReload();
   setDate();

--- a/modules/utils.js
+++ b/modules/utils.js
@@ -84,7 +84,7 @@ const moveGridView = () => {
   $gridView.classList.remove("hidden");
   $listView.classList.add("hidden");
 
-  getState("isGridMode", true);
+  setState("isGridMode", true);
   const MEDIA_NUM = MEDIA.GRID_ROW_NUM * MEDIA.GRID_COLUMN_NUM;
   setNewPage();
 };
@@ -105,7 +105,7 @@ const moveListView = () => {
   $leftArrow.classList.remove("hidden");
   $rightArrow.classList.remove("hidden");
 
-  getState("isGridMode", false);
+  setState("isGridMode", false);
 
   setCategoryBar();
   setFullList();

--- a/modules/utils.js
+++ b/modules/utils.js
@@ -1,9 +1,7 @@
-import { IMAGE, MEDIA, MESSAGE, STATE } from "../constant.js";
-import { setState } from "../observer/observer.js";
+import { IMAGE, MEDIA, MESSAGE } from "../constant.js";
+import { getState, setState } from "../observer/observer.js";
 import { changeImgSrc, setNewPage } from "./grid.js";
 import { setCategoryBar, setFullList, setListView } from "./list.js";
-
-const MEDIA_NUM = MEDIA.GRID_ROW_NUM * MEDIA.GRID_COLUMN_NUM;
 
 const $gridIcon = document.querySelector(".nav-grid");
 const $listIcon = document.querySelector(".nav-list");
@@ -34,7 +32,7 @@ const setColorModeEvent = () => {
 
     $colorModeBtn.src =
       $html.className === "dark" ? IMAGE.SUN_ICON : IMAGE.MOON_ICON;
-    STATE.MODE.IS_GRID ? changeImgSrc() : setListView();
+    getState("isGridMode") ? changeImgSrc() : setListView();
   });
 };
 /**
@@ -86,7 +84,7 @@ const moveGridView = () => {
   $gridView.classList.remove("hidden");
   $listView.classList.add("hidden");
 
-  STATE.MODE.IS_GRID = true;
+  getState("isGridMode", true);
   const MEDIA_NUM = MEDIA.GRID_ROW_NUM * MEDIA.GRID_COLUMN_NUM;
   setNewPage();
 };
@@ -107,7 +105,7 @@ const moveListView = () => {
   $leftArrow.classList.remove("hidden");
   $rightArrow.classList.remove("hidden");
 
-  STATE.MODE.IS_GRID = false;
+  getState("isGridMode", false);
 
   setCategoryBar();
   setFullList();
@@ -119,19 +117,22 @@ const initSubsModalView = () => {
   const $subBtnNo = document.querySelectorAll(".subs-alert_btn")[1];
 
   $subBtnYes.addEventListener("click", () => {
-    const subIdx = STATE.SELECT_SUBSCRIBE_IDX;
-    STATE.SUBSCRIBE_LIST.splice(subIdx, 1);
+    const subIdx = getState("selectSubscribeIdx");
+
+    const newSubscribeList = getState("subscribeList");
+    newSubscribeList.splice(subIdx, 1);
+    setState("subscribeList", newSubscribeList);
+
     $subsAlert.classList.add("hidden");
 
-    alert(MESSAGE.UNSUBSCRIBE);
-
-    if (STATE.MODE.IS_GRID) {
-      const MEDIA_NUM = MEDIA.GRID_ROW_NUM * MEDIA.GRID_COLUMN_NUM;
+    if (getState("isGridMode")) {
       setNewPage();
     } else {
       setCategoryBar();
       setFullList();
     }
+
+    alert(MESSAGE.UNSUBSCRIBE);
   });
   $subBtnNo.addEventListener("click", () => {
     $subsAlert.classList.add("hidden");

--- a/observer/observer.js
+++ b/observer/observer.js
@@ -1,0 +1,28 @@
+const globalStates = {};
+
+export function initState({ key, defaultState }) {
+  globalStates[key] = {
+    state: defaultState,
+    observers: new Set(),
+  };
+  return key;
+}
+
+export function getState(key) {
+  return globalStates[key].state;
+}
+
+export function setState(key, state) {
+  globalStates[key].state = state;
+  notify(key);
+}
+
+function notify(key) {
+  globalStates[key].observers.forEach((observer) => {
+    observer();
+  });
+}
+
+export function register(key, observer) {
+  globalStates[key].observers.add(observer);
+}

--- a/observer/observer.js
+++ b/observer/observer.js
@@ -23,6 +23,8 @@ function notify(key) {
   });
 }
 
-export function register(key, observer) {
-  globalStates[key].observers.add(observer);
+export function register(keyList, observer) {
+  keyList.map((key) => {
+    globalStates[key].observers.add(observer);
+  });
 }

--- a/store/index.js
+++ b/store/index.js
@@ -1,0 +1,3 @@
+export * from "./mode.js";
+export * from "./subscribe.js";
+export * from "./media.js";

--- a/store/media.js
+++ b/store/media.js
@@ -1,0 +1,23 @@
+import { initState } from "../observer/observer.js";
+
+const gridPageNum = initState({
+  key: "gridPageNum",
+  defaultState: 0,
+});
+
+const listCateIdx = initState({
+  key: "listCateIdx",
+  defaultState: 0,
+});
+
+const listCateMediaIdx = initState({
+  key: "listCateMediaIdx",
+  defaultState: 0,
+});
+
+const listSubsMediaIdx = initState({
+  key: "listSubsMediaIdx",
+  defaultState: 0,
+});
+
+export { gridPageNum, listCateIdx, listCateMediaIdx, listSubsMediaIdx };

--- a/store/mode.js
+++ b/store/mode.js
@@ -1,0 +1,18 @@
+import { initState } from "../observer/observer.js";
+
+const isLightMode = initState({
+  key: "isLightMode",
+  defaultState: true,
+});
+
+const isGridMode = initState({
+  key: "isGridMode",
+  defaultState: true,
+});
+
+const isTotalMode = initState({
+  key: "isTotalMode",
+  defaultState: true,
+});
+
+export { isLightMode, isGridMode, isTotalMode };

--- a/store/subscribe.js
+++ b/store/subscribe.js
@@ -2,7 +2,7 @@ import { initState } from "../observer/observer.js";
 
 const subscribeList = initState({
   key: "subscribeList",
-  defaultState: [],
+  defaultState: [1, 6, 18, 39, 25, 41],
 });
 
 const selectSubscribeIdx = initState({

--- a/store/subscribe.js
+++ b/store/subscribe.js
@@ -2,10 +2,7 @@ import { initState } from "../observer/observer.js";
 
 const subscribeList = initState({
   key: "subscribeList",
-  defaultState: [
-    1, 6, 18, 39, 25, 41, 4, 5, 7, 8, 9, 14, 19, 21, 22, 23, 24, 26, 27, 28, 29,
-    33, 43, 64, 75, 88,
-  ],
+  defaultState: [1, 6, 18, 39, 25],
 });
 
 const selectSubscribeIdx = initState({

--- a/store/subscribe.js
+++ b/store/subscribe.js
@@ -1,0 +1,13 @@
+import { initState } from "../observer/observer.js";
+
+const subscribeList = initState({
+  key: "subscribeList",
+  defaultState: [],
+});
+
+const selectSubscribeIdx = initState({
+  key: "selectSubscribeIdx",
+  defaultState: 0,
+});
+
+export { subscribeList, selectSubscribeIdx };

--- a/store/subscribe.js
+++ b/store/subscribe.js
@@ -2,7 +2,10 @@ import { initState } from "../observer/observer.js";
 
 const subscribeList = initState({
   key: "subscribeList",
-  defaultState: [1, 6, 18, 39, 25, 41],
+  defaultState: [
+    1, 6, 18, 39, 25, 41, 4, 5, 7, 8, 9, 14, 19, 21, 22, 23, 24, 26, 27, 28, 29,
+    33, 43, 64, 75, 88,
+  ],
 });
 
 const selectSubscribeIdx = initState({


### PR DESCRIPTION
### 📌 ISSUE
1. JeeeunOh#9
2. JeeeunOh#10

### 📌 고민했던 내용
### ✏️ Day 1 
**[Store 분리]**
기존 STATE는 하나의 전역객체 아래에 여러개의 키로 상태가 들어가 있었고 하나의 STATE 아래에서 모든 전역변수를 관리하는 것이 불필요하다고 생각되었습니다. 이에, Store 를 분리하여 이를 개선하였습니다.

<img width="164" alt="image" src="https://github.com/softeerbootcamp-2nd/fe-newsstand/assets/65931227/e15589ce-cd18-460b-9305-098dd99d4ac9">

<br/>

**[과도한 리렌더링으로 인한 스택오버플로우]**
옵저버패턴 적용 시, A 컴포넌트에서 상태를 변경하면 B 컴포넌트가 리렌더링되며 상태를 변경하고 다시 A가 리렌더링되어 스택 오버플로우가 발생하는 문제가 있었습니다. 이에, 변경 상태의 시작점인 A 컴포넌트에만 상태를 register 하게 설정해줌으로써 이를 해결하였습니다.
