### PR TITLE
[배성준] fe-newsstand 4주차

### DIFF
--- a/css/constant.css
+++ b/css/constant.css
@@ -1,4 +1,4 @@
-:root[color-theme='light']{
+:root{
   --bold-L: 700 24px "Pretendard";
   --bold-M: 700 16px "Pretendard";
   --bold-R: 700 14px "Pretendard";
@@ -7,7 +7,6 @@
   --medium-M: 500 16px/22px "Pretendard";
   --medium-R: 500 14px "Pretendard";
   --medium-S: 500 12px "Pretendard";
-
   --grayscale-white-alt : rgba(255, 255, 255, 0.7);
   --grayscale-white : #FFFFFF;
   --grayscale-50 : #F5F9F9;
@@ -19,30 +18,36 @@
   --grayscale-black : #14212B;
   --blue-100 : #7890E7;
   --blue-500 : #4362D0;
+}
+:root[color-theme='light']{
+  --text-strong : var(--grayscale-black);
+  --text-bold : var(--grayscale-500);
+  --text-default : var(--grayscale-400);
+  --text-weak : var(--grayscale-200);
+  --text-white-default : var(--grayscale-white);
+  --text-white-weak : var(--grayscale-white-alt);
+  --text-point : var(--blue-500);
+  --surface-default : var(--grayscale-white);
+  --surface-alt : var(--grayscale-50);
+  --surface-brand-default : var(--blue-500);
+  --surface-brand-alt : var(--blue-100);
+  --border-bold : var(--grayscale-300);
   --border-default : 1px solid var(--grayscale-100);
 }
 
 :root[color-theme='dark']{
-  --bold-L: 700 24px "Pretendard";
-  --bold-M: 700 16px "Pretendard";
-  --bold-R: 700 14px "Pretendard";
-  --bold-S: 700 12px "Pretendard";
-
-  --medium-M: 500 16px/22px "Pretendard";
-  --medium-R: 500 14px "Pretendard";
-  --medium-S: 500 12px "Pretendard";
-  --grayscale-white-alt: #ffffff;
-  --grayscale-white: #14212b;
-  --grayscale-50: #4b5966;
-  --grayscale-100: #5f6e76;
-  --grayscale-200: #ffffff;
-  --grayscale-300: rgba(255, 255, 255, 0.7);
-  --grayscale-400: #d2dae0;
-  --grayscale-500: #f5f7f9;
-  --grayscale-black: rgba(255, 255, 255, 0.7);
-
-  --blue-100: #7890e7;
-  --blue-500: #4362d0;
+  --text-strong : var(--grayscale-white);
+  --text-bold : var(--grayscale-50);
+  --text-default : var(--grayscale-100);
+  --text-weak : var(--grayscale-white-alt);
+  --text-white-default : var(--grayscale-white);
+  --text-white-weak : var(--grayscale-white-alt);
+  --text-point : var(--blue-500);
+  --surface-default : var(--grayscale-black);
+  --surface-alt : var(--grayscale-500);
+  --surface-brand-default : var(--blue-500);
+  --surface-brand-alt : var(--blue-100);
+  --border-bold : var(--grayscale-white-alt);
   --border-default : 1px solid var(--grayscale-400);
 }
 .display-bold24 {
@@ -92,47 +97,47 @@
 }
 
 .text-strong {
-  color: var(--grayscale-black);
+  color: var(--text-strong);
 }
 
 .text-bold {
-  color: var(--grayscale-500);
+  color: var(--text-bold);
 }
 
 .text-default {
-  color: var(--grayscale-400);
+  color: var(--text-default);
 }
 
 .text-weak {
-  color: var(--grayscale-200);
+  color: var(--text-weak);
 }
 
 .text-white-default {
-  color: var(--grayscale-white);
+  color: var(--text-white-default);
 }
 
 .text-white-weak {
-  color: var(--grayscale-white-alt);
+  color: var(--text-white-weak);
 }
 
 .text-point {
-  color: var(--blue-500);
+  color: var(--text-point);
 }
 
 .surface-default {
-  background-color: var(--grayscale-white);
+  background-color: var(--surface-default);
 }
 
 .surface-alt {
-  background-color: var(--grayscale-50);
+  background-color: var(--surface-alt);
 }
 
 .surface-brand-default {
-  background-color: var(--blue-500);
+  background-color: var(--surface-brand-default);
 }
 
 .surface-brand-alt {
-  background-color: var(--blue-100);
+  background-color: var(--surface-brand-alt);
 }
 
 .flex-center{

--- a/css/constant.css
+++ b/css/constant.css
@@ -1,4 +1,4 @@
-:root {
+:root[color-theme='light']{
   --bold-L: 700 24px "Pretendard";
   --bold-M: 700 16px "Pretendard";
   --bold-R: 700 14px "Pretendard";
@@ -22,6 +22,29 @@
   --border-default : 1px solid var(--grayscale-100);
 }
 
+:root[color-theme='dark']{
+  --bold-L: 700 24px "Pretendard";
+  --bold-M: 700 16px "Pretendard";
+  --bold-R: 700 14px "Pretendard";
+  --bold-S: 700 12px "Pretendard";
+
+  --medium-M: 500 16px/22px "Pretendard";
+  --medium-R: 500 14px "Pretendard";
+  --medium-S: 500 12px "Pretendard";
+  --grayscale-white-alt: #ffffff;
+  --grayscale-white: #14212b;
+  --grayscale-50: #4b5966;
+  --grayscale-100: #5f6e76;
+  --grayscale-200: #ffffff;
+  --grayscale-300: rgba(255, 255, 255, 0.7);
+  --grayscale-400: #d2dae0;
+  --grayscale-500: #f5f7f9;
+  --grayscale-black: rgba(255, 255, 255, 0.7);
+
+  --blue-100: #7890e7;
+  --blue-500: #4362d0;
+  --border-default : 1px solid var(--grayscale-400);
+}
 .display-bold24 {
   font: var(--bold-L);
 }

--- a/css/style.css
+++ b/css/style.css
@@ -9,6 +9,7 @@ body {
     flex-direction : column;
     min-width: 930px;
     height: 100vh;
+    background-color: var(--grayscale-white);
 }
 .news_stand_wrapper {
     width: 930px;
@@ -187,6 +188,7 @@ ul li:hover .media-hover .subscribedWrapper {
     position: absolute;
     top: -36px;
     left: 0;
+
 }
 .news_title_wrapper a{
     display: block;
@@ -195,7 +197,6 @@ ul li:hover .media-hover .subscribedWrapper {
     -webkit-line-clamp: 1;
     -webkit-box-orient:vertical;
     overflow: hidden;
-    color: #000;
 }
 
 .article_wrapper p:hover{

--- a/css/style.css
+++ b/css/style.css
@@ -324,12 +324,27 @@ ul li:hover .media-hover .subscribedWrapper {
     flex-direction: column;
     gap : 16px;
 }
+.listView_wrapper .media_section .thumbnail p{
+    cursor:pointer;
+}
 
+.listView_wrapper .media_section .thumbnail img{
+    transition: all 0.2s linear;
+}
+
+.listView_wrapper .media_section .thumbnail img:hover{
+    transform: scale(1.05);
+}
 .listView_wrapper .media_section .media_section_list {
     display:flex;
     flex-direction: column;
     gap : 16px;
 }
+.listView_wrapper .media_section .media_section_list p{
+    cursor : pointer;
+}
+
+
 #arrow_wrapper_left_list{
     position: absolute;
     left:-72px;

--- a/css/style.css
+++ b/css/style.css
@@ -94,6 +94,7 @@ nav {
 .view_wrapper {
     width:930px;
     height:388px;
+    position:relative;
 }
 .grid_wrapper{
     width:100%;
@@ -416,4 +417,64 @@ ul li:hover .media-hover .subscribedWrapper {
 
 .toggleSwitch, .toggleButton {
     transition: all 0.2s ease-in;
+}
+
+.unsubscribe_alert{
+    position:absolute;
+    top: 32%;
+    left: 32.7%;
+    display: flex;
+    flex-direction : column;
+    width: 320px;
+    height:140px;
+    border: 1px solid var(--border-border-default, #D2DAE0);
+    background: var(--surface-surface-default, #FFF);
+    align-items: flex-start;
+    align-items: center;
+}
+
+.unsubscribe_alert .text{
+    display:flex;
+    padding:24px;
+    text-align: center;
+}
+.unsubscribe_alert .button_wrapper{
+    display:flex;
+    width:100%;
+    height:100%;
+}
+
+.unsubscribe_alert .button_wrapper .button_unsubscribe{
+    width:50%;
+    display:flex;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    font-family: Pretendard;
+    font-size: 16px;
+    font-style: normal;
+    font-weight: 500;
+    line-height: 22px; /* 137.5% */
+    border: var(--border-default);
+}
+.unsubscribe_alert .button_wrapper .button_cancel{
+    width:50%;
+    display:flex;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    font-family: Pretendard;
+    font-size: 16px;
+    font-style: normal;
+    font-weight: 500;
+    line-height: 22px; /* 137.5% */
+    border: var(--border-default);
+}
+
+.unsubscribe_alert .button_wrapper p{
+    cursor:pointer;
+}
+
+.display_none{
+    display:none;
 }

--- a/css/style.css
+++ b/css/style.css
@@ -9,7 +9,7 @@ body {
     flex-direction : column;
     min-width: 930px;
     height: 100vh;
-    background-color: var(--grayscale-white);
+    background-color: var(--surface-default);
 }
 .news_stand_wrapper {
     width: 930px;

--- a/css/style.css
+++ b/css/style.css
@@ -6,11 +6,13 @@ body {
     display: flex;
     align-items: center;
     justify-content: center;
+    flex-direction : column;
     min-width: 930px;
     height: 100vh;
 }
 .news_stand_wrapper {
     width: 930px;
+    position: relative;
 }
 
 /* header */
@@ -354,4 +356,44 @@ ul li:hover .media-hover .subscribedWrapper {
 
 .snackBar.hide { 
     display: none;
+}
+
+.mode_wrapper {
+    position: absolute;
+    bottom: 120%;
+    right: 0;
+}
+.toggleSwitch {
+    width: 100px;
+    height: 50px;
+    display: block;
+    position: relative;
+    border-radius: 30px;
+    background-color: #000;
+    box-shadow: 0 0 16px 3px rgba(0 0 0 / 15%);
+    cursor: pointer;
+}
+  
+.toggleSwitch .toggleButton {
+    width: 40px;
+    height: 40px;
+    position: absolute;
+    top: 50%;
+    left: 4px;
+    transform: translateY(-50%);
+    border-radius: 50%;
+    background: #fff;
+}
+
+#toggle:checked ~ .toggleSwitch {
+    background: #fff;
+}
+
+#toggle:checked ~ .toggleSwitch .toggleButton {
+    left: calc(100% - 44px);
+    background: #000;
+}
+
+.toggleSwitch, .toggleButton {
+    transition: all 0.2s ease-in;
 }

--- a/css/style.css
+++ b/css/style.css
@@ -168,7 +168,7 @@ ul li:hover .media-hover .subscribedWrapper {
     align-items: center;
     gap: 2px;
     border-radius: 50px;
-    border: 1px solid var(--border-border-default, #D2DAE0);
+    border:var(--border-default);
     cursor:pointer;
 }
 
@@ -311,7 +311,7 @@ ul li:hover .media-hover .subscribedWrapper {
     align-items: center;
     gap: 2px;
     border-radius: 50px;
-    border: 1px solid var(--border-border-default, #D2DAE0);
+    border: var(--border-default);
     cursor : pointer;
 }
 
@@ -362,7 +362,7 @@ ul li:hover .media-hover .subscribedWrapper {
 }
 
 .snackBar{
-    color: var(--text-text-white-default, #FFF);
+    color: var(--text-white-default);
     display: inline-flex;
     padding: 16px 24px;
     align-items: flex-start;
@@ -427,8 +427,8 @@ ul li:hover .media-hover .subscribedWrapper {
     flex-direction : column;
     width: 320px;
     height:140px;
-    border: 1px solid var(--border-border-default, #D2DAE0);
-    background: var(--surface-surface-default, #FFF);
+    border: var(--border-default);
+    background: var(--surface-default);
     align-items: flex-start;
     align-items: center;
 }
@@ -477,4 +477,12 @@ ul li:hover .media-hover .subscribedWrapper {
 
 .display_none{
     display:none;
+}
+
+.sub_none {
+    width:100%;
+    height:100%;
+    display:flex;
+    align-items: center;
+    justify-content: center;
 }

--- a/css/style.css
+++ b/css/style.css
@@ -235,6 +235,10 @@ ul li:hover .media-hover .subscribedWrapper {
     overflow:auto;
 }
 
+.list_wrapper .category::-webkit-scrollbar{
+    display:none;
+}
+
 .list_wrapper .category .category_item {
     display: flex;
     padding : 0 16px 0 16px;

--- a/index.html
+++ b/index.html
@@ -11,6 +11,12 @@
 
 <body>
 	<div class="news_stand_wrapper">
+		<div class="mode_wrapper">
+			<input type="checkbox" id="toggle" hidden> 
+			<label for="toggle" class="toggleSwitch">
+				<span class="toggleButton"></span>
+			</label>
+		</div>
 		<header>
 			<div class="title_wrapper">
 				<img src="assets/images/newsstand.svg" alt="뉴스스탠드 아이콘">

--- a/index.html
+++ b/index.html
@@ -39,10 +39,10 @@
 		</div>
 		<main>
 			<div class="media_wrapper">
-				<div class = "snackBar display-medium16 surface-brand-default hide">
+				<div class = "snackBar display-medium16 surface-brand-default hide">	
 					<p>내가 구독한 언론사에 추가되었습니다.</p>
 				</div>
-				<nav>
+				<nav>	
 					<div class="media_select_wrapper">
 						<div class="media_select text-strong selected-bold16">전체 언론사</div>
 						<div class="media_select text-weak available-medium16">내가 구독한 언론사</div>
@@ -64,6 +64,17 @@
 						</div>
 					</div>
 					<div class="list_wrapper">
+						<div class="unsubscribe_alert">
+							<div class="text">
+								<p class="name">
+									여성경제신문
+								</p>
+								<p class="description">을(를)<br/>구독해지하시겠습니까?</p>
+							</div>
+							<div class="button_wrapper">
+								
+							</div>
+						</div>
 						<div class="category surface-alt text-weak">
 						</div>
 						<div class="listView_wrapper">
@@ -73,7 +84,7 @@
 							<div class="media_info">
 								<img src="assets/images/logo/light/0.png" alt = "한국농어촌방송">
 								<p class = "media_info_edited text-default display-medium12">
-									2023.02.10. 18:27 편집
+									
 								</p>
 								<div class="subscribed surface-alt available-medium12">
 									<img src = "assets/images/add.svg">
@@ -83,7 +94,7 @@
 							<div class="media_section available-medium16">
 								<div class="thumbnail">
 									<img src="https://picsum.photos/320/200">
-									<p class="text-strong">또 국민연급의 몽니...현대百 지주사 불발</p>
+									<p class="text-strong"></p>
 								</div>
 								<div class="media_section_list text-bold">
 									<p></p>
@@ -92,7 +103,7 @@
 									<p></p>
 									<p></p>
 									<p></p>
-									<p class="source text-weak display-medium14">서울경제 언론사에서 직접 편집한 뉴스입니다.</p>
+									<p class="source text-weak display-medium14"></p>
 								</div>
 							</div>
 							<div id="arrow_wrapper_right_list">

--- a/index.html
+++ b/index.html
@@ -64,17 +64,6 @@
 						</div>
 					</div>
 					<div class="list_wrapper">
-						<div class="unsubscribe_alert">
-							<div class="text">
-								<p class="name">
-									여성경제신문
-								</p>
-								<p class="description">을(를)<br/>구독해지하시겠습니까?</p>
-							</div>
-							<div class="button_wrapper">
-								
-							</div>
-						</div>
 						<div class="category surface-alt text-weak">
 						</div>
 						<div class="listView_wrapper">
@@ -108,6 +97,19 @@
 							</div>
 							<div id="arrow_wrapper_right_list">
 								<img src="assets/images/right.svg" alt="화살표">
+							</div>
+						</div>
+					</div>
+					<div class="unsubscribe_alert display_none">
+						<div class="text">
+							<p class="description available-medium16 text-default"><span class="name display-bold16 text-strong">{언론사명}</span>을(를)<br/>구독해지하시겠습니까?</p>
+						</div>
+						<div class="button_wrapper">
+							<div class="button_unsubscribe available-medium16">
+								<p class="hover-medium16 text-default">예, 해지합니다</p>
+							</div>
+							<div class="button_cancel available-medium16">
+								<p class="hover-medium16 text-strong">아니오</p>
 							</div>
 						</div>
 					</div>

--- a/script/app.js
+++ b/script/app.js
@@ -3,11 +3,12 @@ import headerInit from './main/header.js';
 import rollingInit from './main/rolling.js';
 import getTopicInit from './main/topic.js';
 import selectorInit from './main/selector.js';
-
+import modeInit from './main/mode.js';
 ( () => {
   headerInit();
   rollingInit();
   getTopicInit();
   selectorInit();
   gridInit();
+  modeInit();
 })();

--- a/script/app.js
+++ b/script/app.js
@@ -5,10 +5,10 @@ import getTopicInit from './main/topic.js';
 import selectorInit from './main/selector.js';
 import modeInit from './main/mode.js';
 ( () => {
+  modeInit();
   headerInit();
   rollingInit();
   getTopicInit();
   selectorInit();
   gridInit();
-  modeInit();
 })();

--- a/script/app.js
+++ b/script/app.js
@@ -4,6 +4,7 @@ import rollingInit from './main/rolling.js';
 import getTopicInit from './main/topic.js';
 import selectorInit from './main/selector.js';
 import modeInit from './main/mode.js';
+import listViewInit from './main/listView.js';
 ( () => {
   modeInit();
   headerInit();
@@ -11,4 +12,5 @@ import modeInit from './main/mode.js';
   getTopicInit();
   selectorInit();
   gridInit();
+  listViewInit();
 })();

--- a/script/main/gridView.js
+++ b/script/main/gridView.js
@@ -1,6 +1,6 @@
 import { shuffle, getJSON } from '../util/util.js';
 import { MEDIA } from '../constants.js'; // magic 넘버
-import { pageStore,subscribedStore,mode } from '../util/store.js'; 
+import { pageStore,subscribedStore,mode,viewMode } from '../util/store.js'; 
 /* 
   media_data = [
   { name: '한국농어촌방송', src: '0.png' },
@@ -55,7 +55,7 @@ export const GridController = {
     const imageElement = mediaLogo[index];
     if(mode.getState() === 'All'){
       imageElement.className = `media_logo media_${logoIndex[media]}`;
-      imageElement.src = `assets/images/logo/light/${media_data[logoIndex[media]]?.src}`;
+      imageElement.src = `assets/images/logo/${viewMode.getState()}/${media_data[logoIndex[media]]?.src}`;
 
       // 이미지랑 같은 노드인 구독하기 or 해지하기 제거
       imageElement.nextElementSibling?.remove();
@@ -69,7 +69,7 @@ export const GridController = {
     }
     else{
       imageElement.className = `media_logo media_${media}`;
-      imageElement.src = `assets/images/logo/light/${media_data[media]?.src}`;
+      imageElement.src = `assets/images/logo/${viewMode.getState()}/${media_data[media]?.src}`;
 
       // 이미지랑 같은 노드인 구독하기 or 해지하기 제거
       imageElement.nextElementSibling?.remove();

--- a/script/main/gridView.js
+++ b/script/main/gridView.js
@@ -1,6 +1,7 @@
 import { shuffle, getJSON } from '../util/util.js';
 import { MEDIA } from '../constants.js'; // magic 넘버
-import { pageStore,subscribedStore,mode,viewMode,progressedIdx } from '../util/store.js'; 
+import { pageStore,subscribedStore,mode,viewMode,progressedIdx, timeoutId } from '../util/store.js'; 
+import { alertUnsubscribe } from './subscribe.js';
 /* 
   media_data = [
   { name: '한국농어촌방송', src: '0.png' },
@@ -109,22 +110,19 @@ export const GridController = {
         subscribedStore.setState([...subscribedStore.getState(),logoIndex]);
         const snackBar = document.querySelector('.snackBar');
         snackBar.classList.remove('hide');
-        setTimeout(function() {
+        const timeout = setTimeout(function() {
           progressedIdx.setState(0);
           snackBar.classList.add('hide');
           mode.setState('Sub');
         }, 3000);
+        timeoutId.setState(timeout);
       });
+
     }
     
     else{
       wrapperElement.addEventListener('click', function(event) {
-        let index = subscribedStore.getState().indexOf(logoIndex);
-        if (index !== -1) {
-          let newState = [...subscribedStore.getState()];
-          newState.splice(index, 1);
-          subscribedStore.setState(newState);
-        }
+        alertUnsubscribe(media_data[logoIndex]["name"],logoIndex);
       })
     }
 

--- a/script/main/gridView.js
+++ b/script/main/gridView.js
@@ -1,6 +1,6 @@
 import { shuffle, getJSON } from '../util/util.js';
 import { MEDIA } from '../constants.js'; // magic 넘버
-import { pageStore,subscribedStore,mode,viewMode } from '../util/store.js'; 
+import { pageStore,subscribedStore,mode,viewMode,progressedIdx } from '../util/store.js'; 
 /* 
   media_data = [
   { name: '한국농어촌방송', src: '0.png' },
@@ -110,7 +110,8 @@ export const GridController = {
         const snackBar = document.querySelector('.snackBar');
         snackBar.classList.remove('hide');
         setTimeout(function() {
-          snackBar.classList.add('hide');  
+          progressedIdx.setState(0);
+          snackBar.classList.add('hide');
           mode.setState('Sub');
         }, 3000);
       });

--- a/script/main/gridView.js
+++ b/script/main/gridView.js
@@ -159,13 +159,11 @@ export const GridController = {
   */
   setLiList() {
     const ul = document.querySelector(".grid_wrapper ul");
-    ul.innerHTML = '';
-    const liHTML = Array(MEDIA.PAGE_SIZE).fill().map(() => `
+    ul.innerHTML = Array(MEDIA.PAGE_SIZE).fill().map(() => `
       <li>
         <img src="" alt="" class="media_logo">
       </li>
     `).join('');
-    ul.innerHTML += liHTML;
   },
 };
 

--- a/script/main/gridView.js
+++ b/script/main/gridView.js
@@ -92,9 +92,16 @@ export const GridController = {
   addSubButton(isSub,logoIndex){
     const subElement = document.createElement('div');
     subElement.className = 'media-hover surface-alt';
-    subElement.innerHTML = isSub ? `<div class="subscribedWrapper surface-default"><img src = "assets/images/add.svg">
-    <p class="subscribed_info text-weak available-medium12">구독하기</p></div>` :`<div class="subscribedWrapper surface-default border-default"><img src = "assets/images/delete.svg">
-    <p class="subscribed_info text-weak available-medium12">해지하기</p></div>`;
+    subElement.innerHTML = isSub ? `
+    <div class="subscribedWrapper surface-default">
+      <img src = "assets/images/add.svg">
+      <p class="subscribed_info text-weak available-medium12">구독하기</p>
+    </div>
+    ` :`
+    <div class="subscribedWrapper surface-default border-default">
+      <img src = "assets/images/delete.svg">
+      <p class="subscribed_info text-weak available-medium12">해지하기</p>
+    </div>`;
     const wrapperElement = subElement.querySelector('.subscribedWrapper');
     
     if(isSub){
@@ -155,7 +162,7 @@ export const GridController = {
     ul.innerHTML = '';
     const liHTML = Array(MEDIA.PAGE_SIZE).fill().map(() => `
       <li>
-          <img src="" alt="" class="media_logo">
+        <img src="" alt="" class="media_logo">
       </li>
     `).join('');
     ul.innerHTML += liHTML;

--- a/script/main/listView.js
+++ b/script/main/listView.js
@@ -12,7 +12,6 @@ let lastProgressed;
  */
 export const setNewsData = () => {
   const newsItem = categorizedData[categories[category_page.getState()]][media_page.getState()];
-  console.log(newsItem);
   const index = media_data.findIndex(item => item.name === newsItem["name"]);
   const src = media_data[index].src;
   const selectedCategory = document.querySelectorAll('.category_progress')[category_page.getState()];
@@ -28,7 +27,6 @@ export const setNewsData = () => {
   }
   idx = index;
   // 감싸는 요소에 이벤트 추가
-  // 이전에 이벤트 리스너가 추가된 상태인지 확인하고, 그렇지 않은 경우에만 이벤트 리스너를 추가합니다.
   if (!subscribedElem._hasClickListener) {
     subscribedElem.addEventListener('click', function(e) {
       if (subscribedStore.getState().includes(idx)) {
@@ -45,11 +43,11 @@ export const setNewsData = () => {
         setTimeout(function() {
           snackBar.classList.add('hide');  
           mode.setState('Sub');
-
+          
         }, 3000);
       }
     });
-    subscribedElem._hasClickListener = true; // 이벤트 리스너가 등록되었음을 표시
+    subscribedElem._hasClickListener = true; 
   }
   if(mode.getState()==='All'){
     selectedCategory.innerHTML = (media_page.getState() + 1) + "/" + categorizedData[categories[category_page.getState()]].length;
@@ -329,7 +327,7 @@ export const listViewInit = () => {
     categoriesWrapper = document.querySelector('.category');
   }
   getNewsData();
-  // progressBarControl();
+  progressBarControl();
   setArrowHandler();
   category_page.setState(0);
   media_page.setState(0);

--- a/script/main/listView.js
+++ b/script/main/listView.js
@@ -219,6 +219,9 @@ const updateCategoryProgress = () => {
   setNewsData();
 };
 
+export const resetProgressBar = () => {
+  document.querySelectorAll('.category_item').forEach(item => item.style.background = '');
+}
 /**
  * 
  * @param {Object} items 
@@ -290,7 +293,16 @@ const updatePageAndData = () => {
  */
 const animateProgressBar = (element, endWidth, duration) => {
   const start = performance.now();
+  console.log(lastProgressed);
+  if(lastProgressed){
+    if(lastProgressed !== element){
+      console.log("TEST");
+      lastProgressed.style.background = '';
+      lastProgressed = element;
+    }
+  }
   lastProgressed = element;
+
 
   const step = (timestamp) => {
     const elapsed = timestamp - start;

--- a/script/main/listView.js
+++ b/script/main/listView.js
@@ -72,6 +72,7 @@ function handleSubscribe(newsItem, idx) {
       const snackBar = document.querySelector('.snackBar');
       snackBar.classList.remove('hide');
       setTimeout(function() {
+        progressedIdx.setState(0);
         snackBar.classList.add('hide');  
         mode.setState('Sub');
       }, 3000);
@@ -318,7 +319,6 @@ const animateProgressBar = (element, endWidth, duration) => {
  */
 const progressBarControl = () => {
   const progressBar = document.querySelector(".progressed");
-  console.log(progressBar);
   const duration = 2000;
   const endWidth = 100;
   animateProgressBar(progressBar, endWidth, duration);
@@ -327,6 +327,7 @@ const progressBarControl = () => {
 
 let categoriesWrapper;
 export const listViewInit = () => {
+  console.log("엥");
   cancelAnimationFrame(animationId);
   categories = [];
   animationId = null;
@@ -343,6 +344,7 @@ export const listViewInit = () => {
   }
   media_page.setState(0);
   getNewsData();
+  console.log("데이터가져오기");
   setArrowHandler();
   progressBarControl();
   setNewsData();

--- a/script/main/listView.js
+++ b/script/main/listView.js
@@ -12,12 +12,6 @@ let lastProgressed;
  */
 export const setNewsData = () => {
   const newsItem = categorizedData[categories[category_page.getState()]][media_page.getState()];
-  console.log("------");
-  console.log(categorizedData);
-  console.log(categories);
-  console.log(category_page.getState());
-  console.log(media_page.getState());
-  console.log("------");
   const index = media_data.findIndex(item => item.name === newsItem["name"]);
   const src = media_data[index].src;
   const selectedCategory = document.querySelectorAll('.category_progress')[category_page.getState()];
@@ -85,26 +79,26 @@ export const setNewsData = () => {
  * 데이터 가져와서 카테고리별로 분류하는 함수
  */
 function categorizeData() {
-  let categorizedData = {};
+  const categorizedData = {};
   if(mode.getState()==='All'){
     for(let i = 0; i < newsData.length; i++) {
-      let item = newsData[i];
-      let category = item.category;
+      const item = newsData[i];
+      const category = item.category;
       if(!categorizedData[category]) {
         categorizedData[category] = [];
       }
       categorizedData[category].push(item);
     }
 
-    for (let category in categorizedData) {
+    for (const category in categorizedData) {
       shuffle(categorizedData[category]);
     }
   }
   else{
     for(let i =0;i<subscribedStore.getState().length;i++){
       for(let j = 0; j < newsData.length; j++) {
-        let item = newsData[j];
-        let category = item.name;
+        const item = newsData[j];
+        const category = item.name;
         if(category === media_data[subscribedStore.getState()[i]].name){ // 구독한 목록에 있을 때만 
           if(!categorizedData[category]) {
             categorizedData[category] = [];
@@ -114,6 +108,7 @@ function categorizeData() {
       }   
     }
   }
+  console.log(categorizedData);
   return categorizedData;
 }
 

--- a/script/main/listView.js
+++ b/script/main/listView.js
@@ -12,6 +12,7 @@ let lastProgressed;
  */
 export const setNewsData = () => {
   const newsItem = categorizedData[categories[category_page.getState()]][media_page.getState()];
+  console.log(newsItem);
   const index = media_data.findIndex(item => item.name === newsItem["name"]);
   const src = media_data[index].src;
   const selectedCategory = document.querySelectorAll('.category_progress')[category_page.getState()];
@@ -151,7 +152,6 @@ const setArrowHandler = () => {
   const leftArrowWrapper = document.querySelector("#arrow_wrapper_left_list");
   const rightArrowWrapper = document.querySelector("#arrow_wrapper_right_list");
   
-  // 이벤트 리스너가 이미 등록되어 있다면 리턴하여 다시 추가하지 않습니다.
   if (leftArrowWrapper._hasClickListener || rightArrowWrapper._hasClickListener) {
     return;
   }
@@ -167,8 +167,8 @@ const setArrowHandler = () => {
       media_page.setState(media_page.getState()-1);
     }
     cancelAnimationFrame(animationId);
-    progressBarControl();
     updateCategoryProgress();
+    progressBarControl();
   });
   
   rightArrowWrapper.addEventListener("click", () => {
@@ -185,8 +185,8 @@ const setArrowHandler = () => {
       media_page.setState(media_page.getState()+1);
     }
     cancelAnimationFrame(animationId);
-    progressBarControl();
     updateCategoryProgress();
+    progressBarControl();
   });  
   leftArrowWrapper._hasClickListener = true;
   rightArrowWrapper._hasClickListener = true;
@@ -219,9 +219,6 @@ const updateCategoryProgress = () => {
   setNewsData();
 };
 
-export const resetProgressBar = () => {
-  document.querySelectorAll('.category_item').forEach(item => item.style.background = '');
-}
 /**
  * 
  * @param {Object} items 
@@ -229,9 +226,7 @@ export const resetProgressBar = () => {
  * 카테고리 클릭하면 progressed class 추가하는 함수
  */
 const toggleProgressedClass = (items, index) => {
-  lastProgressed.style.background = '';
   items.forEach(item => item.classList.remove("progressed"));
-  document.querySelectorAll('category_item').forEach(item => item.style.bacgkround = '');
   items[index].classList.add("progressed");
 };
 
@@ -244,6 +239,7 @@ const toggleProgressedClass = (items, index) => {
  */
 const addClickListenerToCategoryItem = (item, index, items) => {
   item.addEventListener("click", () => {
+    updateCategoryProgress();
     toggleProgressedClass(items, index);
     progressBarControl();
   });
@@ -293,21 +289,9 @@ const updatePageAndData = () => {
  */
 const animateProgressBar = (element, endWidth, duration) => {
   const start = performance.now();
-  console.log(lastProgressed);
-  if(lastProgressed){
-    if(lastProgressed !== element){
-      console.log("TEST");
-      lastProgressed.style.background = '';
-      lastProgressed = element;
-    }
-  }
-  lastProgressed = element;
-
-
   const step = (timestamp) => {
     const elapsed = timestamp - start;
     const currentWidth = Math.min((endWidth * elapsed) / duration, endWidth);
-    // setWidth(element, currentWidth);
     element.style.background = `linear-gradient(to right, 
       #4362d0 ${currentWidth}%, 
       #7890E7 0%)`;
@@ -315,11 +299,9 @@ const animateProgressBar = (element, endWidth, duration) => {
       animationId = requestAnimationFrame(step);
     } else {
       updatePageAndData();
-      element.style.background = '';
       progressBarControl();
     }
   };
-
   animationId = requestAnimationFrame(step);
 };
 

--- a/script/main/listView.js
+++ b/script/main/listView.js
@@ -205,7 +205,6 @@ const getNewsData = async () => {
 const updateCategoryProgress = () => {
   var categoryItems = document.querySelectorAll(".category_item");
   var progressedItem = document.querySelector(".category_item.progressed");
-
   categoryItems.forEach(item => item.style.background = '');
   if (progressedItem) {
     progressedItem.classList.remove("progressed");
@@ -213,6 +212,7 @@ const updateCategoryProgress = () => {
 
   if (categoryItems[category_page.getState()]) {
     categoryItems[category_page.getState()].classList.add("progressed");
+    categoryItems[category_page.getState()].scrollIntoView({behavior: "smooth"}); 
   }
   setNewsData();
 };

--- a/script/main/listView.js
+++ b/script/main/listView.js
@@ -12,6 +12,12 @@ let lastProgressed;
  */
 export const setNewsData = () => {
   const newsItem = categorizedData[categories[category_page.getState()]][media_page.getState()];
+  console.log("------");
+  console.log(categorizedData);
+  console.log(categories);
+  console.log(category_page.getState());
+  console.log(media_page.getState());
+  console.log("------");
   const index = media_data.findIndex(item => item.name === newsItem["name"]);
   const src = media_data[index].src;
   const selectedCategory = document.querySelectorAll('.category_progress')[category_page.getState()];
@@ -196,7 +202,6 @@ const getNewsData = async () => {
   categorizedData = categorizeData();
   createCategoryElements(categorizedData);
   setProgressed();
-  setNewsData();
 }
 
 /**
@@ -331,6 +336,8 @@ export const listViewInit = () => {
   setArrowHandler();
   category_page.setState(0);
   media_page.setState(0);
+  setNewsData();
+  
 };
 
 

--- a/script/main/listView.js
+++ b/script/main/listView.js
@@ -1,5 +1,5 @@
 import {getJSON,shuffle } from '../util/util.js';
-import {subscribedStore,mode,category_page,media_page,viewMode,progressedIdx } from '../util/store.js'; 
+import {subscribedStore,mode,category_page,media_page,viewMode,progressedIdx, timeoutId } from '../util/store.js'; 
 import { alertUnsubscribe } from './subscribe.js';
 const media_data = await getJSON("../../assets/data/media_data.json");
 const newsData = await getJSON("../../assets/data/news_data.json");
@@ -71,11 +71,12 @@ function handleSubscribe(newsItem, idx) {
       subscribedStore.setState([...subscribedStore.getState(),idx]);
       const snackBar = document.querySelector('.snackBar');
       snackBar.classList.remove('hide');
-      setTimeout(function() {
+      const timeout = setTimeout(function() {
         progressedIdx.setState(0);
         snackBar.classList.add('hide');  
         mode.setState('Sub');
       }, 3000);
+      timeoutId.setState(timeout);
     }
   }
 }
@@ -319,7 +320,7 @@ const animateProgressBar = (element, endWidth, duration) => {
  */
 const progressBarControl = () => {
   const progressBar = document.querySelector(".progressed");
-  const duration = 2000;
+  const duration = 20000;
   const endWidth = 100;
   animateProgressBar(progressBar, endWidth, duration);
 };
@@ -327,7 +328,6 @@ const progressBarControl = () => {
 
 let categoriesWrapper;
 export const listViewInit = () => {
-  console.log("엥");
   cancelAnimationFrame(animationId);
   categories = [];
   animationId = null;
@@ -344,11 +344,9 @@ export const listViewInit = () => {
   }
   media_page.setState(0);
   getNewsData();
-  console.log("데이터가져오기");
   setArrowHandler();
   progressBarControl();
   setNewsData();
-  
 };
 
 

--- a/script/main/listView.js
+++ b/script/main/listView.js
@@ -1,7 +1,7 @@
 import {getJSON,shuffle } from '../util/util.js';
 const media_data = await getJSON("../../assets/data/media_data.json");
 const newsData = await getJSON("../../assets/data/news_data.json");
-import {subscribedStore,mode,category_page,media_page } from '../util/store.js'; 
+import {subscribedStore,mode,category_page,media_page,viewMode } from '../util/store.js'; 
 let categories = [];
 let categorizedData;
 let animationId;
@@ -61,7 +61,7 @@ export const setNewsData = () => {
   document.querySelector(".thumbnail img").src = "https://picsum.photos/320/200";
   document.querySelector(".thumbnail p").innerHTML = newsItem["main_title"];
   document.querySelector(".source").innerHTML = newsItem["name"] + " 언론사에서 직접 편집한 뉴스입니다.";
-  document.querySelector(".media_info img").src = `assets/images/logo/light/${src}`;
+  document.querySelector(".media_info img").src = `assets/images/logo/${viewMode.getState()}/${src}`;
 
   const media_section_list_p_tags = document.querySelectorAll(".media_section_list p");
   
@@ -329,7 +329,7 @@ export const listViewInit = () => {
     categoriesWrapper = document.querySelector('.category');
   }
   getNewsData();
-  progressBarControl();
+  // progressBarControl();
   setArrowHandler();
   category_page.setState(0);
   media_page.setState(0);

--- a/script/main/mode.js
+++ b/script/main/mode.js
@@ -1,13 +1,14 @@
+import { viewMode } from "../util/store.js";
 const modeInit = () => {
   const checkbox = document.querySelector('#toggle');
   document.documentElement.setAttribute('color-theme', 'light');
   checkbox.addEventListener('change', function() {
     if(this.checked) {
-        console.log('체크박스 설정');
         document.documentElement.setAttribute('color-theme', 'dark');
+        viewMode.setState('dark');
     } else {
-        console.log('체크박스 해제');
         document.documentElement.setAttribute('color-theme', 'light');
+        viewMode.setState('light');
     }
   });
 }

--- a/script/main/mode.js
+++ b/script/main/mode.js
@@ -1,11 +1,13 @@
 const modeInit = () => {
   const checkbox = document.querySelector('#toggle');
-
+  document.documentElement.setAttribute('color-theme', 'light');
   checkbox.addEventListener('change', function() {
     if(this.checked) {
         console.log('체크박스 설정');
+        document.documentElement.setAttribute('color-theme', 'dark');
     } else {
         console.log('체크박스 해제');
+        document.documentElement.setAttribute('color-theme', 'light');
     }
   });
 }

--- a/script/main/mode.js
+++ b/script/main/mode.js
@@ -1,0 +1,13 @@
+const modeInit = () => {
+  const checkbox = document.querySelector('#toggle');
+
+  checkbox.addEventListener('change', function() {
+    if(this.checked) {
+        console.log('체크박스 설정');
+    } else {
+        console.log('체크박스 해제');
+    }
+  });
+}
+
+export default modeInit;

--- a/script/main/selector.js
+++ b/script/main/selector.js
@@ -1,5 +1,4 @@
-import listViewInit from "./listView.js";
-import { pageStore,mode,view } from "../util/store.js";
+import { pageStore,mode,view,category_page,progressedIdx } from "../util/store.js";
 const viewSelector = () => {
   const listBtn = document.querySelector('.view_select img[src$="list_gray.svg"]');
   const gridBtn = document.querySelector('.view_select img[src$="grid_blue.svg"]');
@@ -43,11 +42,14 @@ export const toggleClass = () => {
 const modeSelector = () => {
   const [allMediaDiv, subscribeMediaDiv] = document.querySelectorAll('.media_select');
   allMediaDiv.addEventListener('click', function() {
-    mode.setState('All');
     pageStore.setState(0);
+    category_page.setState(0);
+    mode.setState('All');
     toggleClass();
   });
   subscribeMediaDiv.addEventListener('click', function() {
+    category_page.setState(0);
+    progressedIdx.setState(0);
     mode.setState('Sub');
     pageStore.setState(0);
     toggleClass();

--- a/script/main/selector.js
+++ b/script/main/selector.js
@@ -13,7 +13,6 @@ const viewSelector = () => {
     listBtn.src = "assets/images/list_blue.svg";
     gridBtn.src = "assets/images/grid_gray.svg";
     view.setState('List');
-    listViewInit();
   });
 
   gridBtn.addEventListener('click', () => {

--- a/script/main/subscribe.js
+++ b/script/main/subscribe.js
@@ -1,0 +1,18 @@
+export const alertUnsubscribe = (mediaName,mediaIndex) => {
+  const alert = document.querySelector('.unsubscribe_alert');
+  const alertName = document.querySelector('.unsubscribe_alert .name');
+  const unsubscribeButton = document.querySelector("#unsubscribeButton");
+  const cancelButton = document.querySelector("#cancelButton");
+
+  unsubscribeButton.addEventListener("click", function() {
+    
+  });
+
+  cancelButton.addEventListener("click", function() {
+    console.log(mediaIndex);
+  });
+  alertName.innerHTML = mediaName;
+
+  alert.classList.remove('display_none');
+  
+}

--- a/script/main/subscribe.js
+++ b/script/main/subscribe.js
@@ -1,13 +1,15 @@
-import { subscribedStore,mode} from "../util/store.js";
+import { subscribedStore,mode,timeoutId} from "../util/store.js";
 import listViewInit from "./listView.js";
 export const alertUnsubscribe = (mediaName,mediaIndex) => {
   const alert = document.querySelector('.unsubscribe_alert');
   const alertName = document.querySelector('.unsubscribe_alert .name');
   const unsubscribeButton = document.querySelector(".button_unsubscribe");
   const cancelButton = document.querySelector(".button_cancel");
+
   alertName.innerHTML = mediaName;
   alert.classList.remove('display_none');
-  unsubscribeButton.addEventListener("click", function() {
+
+  const unsubscribeEvent = function() {
     let removeIdx = subscribedStore.getState().indexOf(mediaIndex);
     if (removeIdx !== -1) {
       let newState = [...subscribedStore.getState()];
@@ -18,13 +20,37 @@ export const alertUnsubscribe = (mediaName,mediaIndex) => {
     if(mode.getState()==='Sub'){
       listViewInit();
     }
-  });
-  cancelButton.addEventListener("click", function() {
+  };
+
+  const cancelEvent = function() {
     alert.classList.add('display_none');
+  };
+
+  // 클릭 이벤트 추가
+  unsubscribeButton.addEventListener("click", unsubscribeEvent);
+  cancelButton.addEventListener("click", cancelEvent);
+
+  // 키보드 엔터키 이벤트 추가
+  window.addEventListener('keyup', function (e) {
+    if (e.key === 'Enter') {
+        console.log("T");
+        unsubscribeEvent();
+    }
   });
 }
+
 
 export const removeAlertUnsubscribe = () => {
   const alert = document.querySelector('.unsubscribe_alert');
   alert.classList.add('display_none');
+}
+
+export const resetAlert = () => {
+  // const snackBar = document.querySelector('.snackBar');
+  // const alert = document.querySelector('.unsubscribe_alert');
+  // alert.classList.add('display_none');
+  // snackBar.classList.add('hide');
+  console.log(timeoutId.getState());
+  clearTimeout(timeoutId.getState());
+  console.log("rest");
 }

--- a/script/main/subscribe.js
+++ b/script/main/subscribe.js
@@ -1,18 +1,30 @@
+import { subscribedStore,mode} from "../util/store.js";
+import listViewInit from "./listView.js";
 export const alertUnsubscribe = (mediaName,mediaIndex) => {
   const alert = document.querySelector('.unsubscribe_alert');
   const alertName = document.querySelector('.unsubscribe_alert .name');
-  const unsubscribeButton = document.querySelector("#unsubscribeButton");
-  const cancelButton = document.querySelector("#cancelButton");
-
-  unsubscribeButton.addEventListener("click", function() {
-    
-  });
-
-  cancelButton.addEventListener("click", function() {
-    console.log(mediaIndex);
-  });
+  const unsubscribeButton = document.querySelector(".button_unsubscribe");
+  const cancelButton = document.querySelector(".button_cancel");
   alertName.innerHTML = mediaName;
-
   alert.classList.remove('display_none');
-  
+  unsubscribeButton.addEventListener("click", function() {
+    let removeIdx = subscribedStore.getState().indexOf(mediaIndex);
+    if (removeIdx !== -1) {
+      let newState = [...subscribedStore.getState()];
+      newState.splice(removeIdx, 1);
+      subscribedStore.setState(newState);
+      alert.classList.add('display_none');
+    }
+    if(mode.getState()==='Sub'){
+      listViewInit();
+    }
+  });
+  cancelButton.addEventListener("click", function() {
+    alert.classList.add('display_none');
+  });
+}
+
+export const removeAlertUnsubscribe = () => {
+  const alert = document.querySelector('.unsubscribe_alert');
+  alert.classList.add('display_none');
 }

--- a/script/util/store.js
+++ b/script/util/store.js
@@ -32,3 +32,9 @@ media_page.setObserver( () => {
 })
 
 export const view = createStore('Grid');
+
+export const viewMode = createStore('light');
+viewMode.setObserver(()=>{
+  GridController.setLogoList();
+  setNewsData();
+})

--- a/script/util/store.js
+++ b/script/util/store.js
@@ -11,7 +11,7 @@ pageStore.setObserver(() => {
 export const subscribedStore = createStore([0,1,2,3,4,5,6,7,8,9,10,11]);
 subscribedStore.setObserver( () => {
   GridController.setLogoList();
-  listViewInit();
+  // listViewInit();
 })
 
 export const mode = createStore('All');
@@ -23,19 +23,20 @@ mode.setObserver( () => {
 
 export const category_page = createStore(0);
 category_page.setObserver ( () => {
-  setNewsData();
+  // setNewsData();
 })
 
 export const media_page = createStore(0);
 media_page.setObserver( () => {
-  setNewsData();
+  // setNewsData();
 })
 
 export const view = createStore('Grid');
-
+view.setObserver( () => {
+  listViewInit();
+})
 export const viewMode = createStore('light');
 viewMode.setObserver(()=>{
   GridController.setLogoList();
-  listViewInit();
   setNewsData();
 })

--- a/script/util/store.js
+++ b/script/util/store.js
@@ -36,5 +36,6 @@ export const view = createStore('Grid');
 export const viewMode = createStore('light');
 viewMode.setObserver(()=>{
   GridController.setLogoList();
+  listViewInit();
   setNewsData();
 })

--- a/script/util/store.js
+++ b/script/util/store.js
@@ -1,6 +1,6 @@
 import createStore from './createStore.js';
 import { GridController,PageController } from '../main/gridView.js';
-import { listViewInit,setNewsData } from '../main/listView.js';
+import { listViewInit,setNewsData,resetProgressBar } from '../main/listView.js';
 import { toggleClass } from '../main/selector.js';
 export const pageStore = createStore(0);
 pageStore.setObserver(() => {
@@ -24,6 +24,7 @@ mode.setObserver( () => {
 export const category_page = createStore(0);
 category_page.setObserver ( () => {
   setNewsData();
+  resetProgressBar();
 })
 
 export const media_page = createStore(0);

--- a/script/util/store.js
+++ b/script/util/store.js
@@ -2,6 +2,7 @@ import createStore from './createStore.js';
 import { GridController,PageController } from '../main/gridView.js';
 import { listViewInit,setNewsData } from '../main/listView.js';
 import { toggleClass } from '../main/selector.js';
+import { removeAlertUnsubscribe } from '../main/subscribe.js';
 export const pageStore = createStore(0);
 pageStore.setObserver(() => {
   GridController.setLogoList();
@@ -11,6 +12,7 @@ pageStore.setObserver(() => {
 export const subscribedStore = createStore([0,1,2,3,4,5,6,7,8,9,10,11]);
 subscribedStore.setObserver( () => {
   GridController.setLogoList();
+  setNewsData();
   // listViewInit();
 })
 
@@ -24,11 +26,13 @@ mode.setObserver( () => {
 export const category_page = createStore(0);
 category_page.setObserver ( () => {
   // setNewsData();
+  removeAlertUnsubscribe();
 })
 
 export const media_page = createStore(0);
 media_page.setObserver( () => {
   // setNewsData();
+  removeAlertUnsubscribe();
 })
 
 export const view = createStore('Grid');
@@ -40,3 +44,5 @@ viewMode.setObserver(()=>{
   GridController.setLogoList();
   setNewsData();
 })
+
+export const progressedIdx = createStore(0);

--- a/script/util/store.js
+++ b/script/util/store.js
@@ -3,13 +3,14 @@ import { GridController,PageController } from '../main/gridView.js';
 import { listViewInit,setNewsData } from '../main/listView.js';
 import { toggleClass } from '../main/selector.js';
 import { removeAlertUnsubscribe } from '../main/subscribe.js';
+import { resetAlert } from '../main/subscribe.js';
 export const pageStore = createStore(0);
 pageStore.setObserver(() => {
   GridController.setLogoList();
   PageController.setArrowVisible();
 });
 
-export const subscribedStore = createStore([0,1,2,3,4,5,6,7,8,9,10,11]);
+export const subscribedStore = createStore([0,1,2,3,4]);
 subscribedStore.setObserver( () => {
   GridController.setLogoList();
   setNewsData();
@@ -46,3 +47,5 @@ viewMode.setObserver(()=>{
 })
 
 export const progressedIdx = createStore(0);
+
+export const timeoutId = createStore(0);

--- a/script/util/store.js
+++ b/script/util/store.js
@@ -1,6 +1,6 @@
 import createStore from './createStore.js';
 import { GridController,PageController } from '../main/gridView.js';
-import { listViewInit,setNewsData,resetProgressBar } from '../main/listView.js';
+import { listViewInit,setNewsData } from '../main/listView.js';
 import { toggleClass } from '../main/selector.js';
 export const pageStore = createStore(0);
 pageStore.setObserver(() => {
@@ -24,7 +24,6 @@ mode.setObserver( () => {
 export const category_page = createStore(0);
 category_page.setObserver ( () => {
   setNewsData();
-  resetProgressBar();
 })
 
 export const media_page = createStore(0);

--- a/script/util/util.js
+++ b/script/util/util.js
@@ -15,4 +15,5 @@ const getJSON = async (url) => {
     return null;
   }
 };
+
 export {shuffle, getJSON};


### PR DESCRIPTION
## ✅ 사전 작업
구독한 언론사 리스트 뷰 보기에서 중간에 있는 언론사 구독 해지 시, 처음부터 다시 프로그래스바가 실행되었는데, 해지한 언론사 이후의 언론사부터 프로그래스바 실행하도록 수정하였습니다.

## 📝 Feature1 [#1](https://github.com/westofsky/fe-newsstand/issues/10)
- [x] 설계
- [x] 구현
- [x] refactoring

### 구현 내용
- westofsky/fe-newsstand#10
- 구독한 언론사들을 store로 관리하였습니다.
- 해지하기 알럿이 뜬 뒤, 클릭이 아닌 엔터를 눌러도 해지가 되도록 구현하였습니다.

## 📝 Feature1 [#2](https://github.com/westofsky/fe-newsstand/issues/11)
- [x] 설계
- [x] 구현
- [x] refactoring

### 구현 내용
- westofsky/fe-newsstand#11
- `document.documentElement.setAttribute('color-theme', 'light');` 로 color-theme를 바꾸어 다른 css를 적용하였습니다.